### PR TITLE
feat: Improve auth

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,8 +13,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/linters.yml'
-      - 'keystone/**'
-      - 'fuzz/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -22,7 +20,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  rust_min: 1.76.0
+  rust_min: 1.85.0
 
 jobs:
   rustfmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,9 +496,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -969,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1121,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -1635,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -1765,9 +1777,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchit"
@@ -1834,6 +1846,44 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "mockall_double"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ca96e5ac35256ae3e13536edd39b172b88f41615e1d7b653c8ad24524113e8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1987,6 +2037,8 @@ dependencies = [
  "eyre",
  "fernet",
  "http-body-util",
+ "mockall",
+ "mockall_double",
  "regex",
  "rmp",
  "sea-orm",
@@ -2242,6 +2294,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3195,6 +3273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,9 +3756,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
+checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
 dependencies = [
  "getrandom 0.3.1",
  "serde",
@@ -4192,27 +4276,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "openstack_keystone"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Artem Goncharov (gtema)"]
-rust-version = "1.83"  # MSRV
+rust-version = "1.85"  # MSRV
 repository = "https://github.com/gtema/keystone"
 
 [[bin]]
@@ -29,6 +29,7 @@ derive_builder = { version = "^0.20" }
 dyn-clone = { version = "^1.0" }
 eyre = { version = "^0.6" }
 fernet = { version = "^0.2" }
+mockall_double = { version = "^0.3" }
 regex = { version = "^1.11"}
 rmp = { version = "^0.8" }
 sea-orm = { version = "^1.1", features = ["sqlx-mysql", "sqlx-postgres", "runtime-tokio"] }
@@ -44,11 +45,12 @@ tracing-subscriber = { version = "^0.3" }
 utoipa = { version = "^5.3", features = ["axum_extras", "chrono"] }
 utoipa-axum = { version = "^0.2" }
 utoipa-swagger-ui = { version = "^9.0", features = ["axum", "vendored"], default-features = false }
-uuid = { version = "^1.13", features = ["v4"] }
+uuid = { version = "^1.14", features = ["v4"] }
 
 [dev-dependencies]
 criterion = { version = "^0.5", features = ["async_tokio"] }
 http-body-util = "^0.1"
+mockall = { version = "^0.13" }
 sea-orm = { version = "*", features = ["mock"]}
 tempfile = { version = "^3.17" }
 

--- a/benches/fernet_token.rs
+++ b/benches/fernet_token.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;

--- a/loadtest/Cargo.toml
+++ b/loadtest/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "load_test"
 version = "0.1.0"
+rust-version = "1.85"  # MSRV
 edition = "2024"
 
 [dependencies]
-goose = "0.17.2"
-tokio = "1.43.0"
+goose = { version = "^0.17" }
+tokio = { version = "^1.43" }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -13,9 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{
+    Json,
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use serde_json::json;
 use thiserror::Error;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,12 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 
 use crate::keystone::ServiceState;
-use crate::provider::Provider;
 
 pub mod auth;
 pub mod error;
@@ -27,9 +25,6 @@ pub mod v3;
 #[openapi(info(version = "3.14.0"))]
 pub struct ApiDoc;
 
-pub fn openapi_router<P>() -> OpenApiRouter<Arc<ServiceState<P>>>
-where
-    P: Provider + 'static,
-{
+pub fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new().nest("/v3", v3::openapi_router())
 }

--- a/src/api/v3/group/types.rs
+++ b/src/api/v3/group/types.rs
@@ -13,9 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{
+    Json,
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -23,7 +23,7 @@ use utoipa::{IntoParams, ToSchema};
 
 use crate::identity::types;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct Group {
     /// Group ID
     pub id: String,
@@ -33,17 +33,17 @@ pub struct Group {
     pub name: String,
     /// Group description
     pub description: Option<String>,
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub extra: Option<Value>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct GroupResponse {
     /// group object
     pub group: Group,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct GroupCreate {
     /// Group domain ID
     pub domain_id: String,
@@ -51,11 +51,11 @@ pub struct GroupCreate {
     pub name: String,
     /// Group description
     pub description: Option<String>,
-    #[serde(flatten)]
+    #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
     pub extra: Option<Value>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct GroupCreateRequest {
     /// Group object
     pub group: GroupCreate,
@@ -77,7 +77,7 @@ impl From<GroupCreateRequest> for types::GroupCreate {
     fn from(value: GroupCreateRequest) -> Self {
         let group = value.group;
         Self {
-            id: String::new(),
+            id: None,
             name: group.name,
             domain_id: group.domain_id,
             extra: group.extra,
@@ -105,7 +105,7 @@ impl IntoResponse for types::Group {
 }
 
 /// Groups
-#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct GroupList {
     /// Collection of group objects
     pub groups: Vec<Group>,

--- a/src/identity/backends/sql/local_user.rs
+++ b/src/identity/backends/sql/local_user.rs
@@ -12,9 +12,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
-use sea_orm::DatabaseConnection;
 use std::collections::HashMap;
 
 use crate::config::Config;
@@ -30,7 +30,10 @@ pub async fn load_local_user_with_passwords<S: AsRef<str>>(
     db: &DatabaseConnection,
     user_id: S,
 ) -> Result<
-    Option<(local_user::Model, impl IntoIterator<Item = password::Model>)>,
+    Option<(
+        local_user::Model,
+        impl IntoIterator<Item = password::Model> + use<S>,
+    )>,
     IdentityDatabaseError,
 > {
     let results: Vec<(local_user::Model, Vec<password::Model>)> = LocalUser::find()
@@ -48,11 +51,7 @@ pub async fn load_local_user_with_passwords<S: AsRef<str>>(
 pub async fn load_local_users_passwords<L: IntoIterator<Item = Option<i32>>>(
     db: &DatabaseConnection,
     user_ids: L,
-) -> Result<
-    //impl IntoIterator<Item = Option<impl IntoIterator<Item = password::Model>>>,
-    Vec<Option<Vec<password::Model>>>,
-    IdentityDatabaseError,
-> {
+) -> Result<Vec<Option<Vec<password::Model>>>, IdentityDatabaseError> {
     let ids: Vec<Option<i32>> = user_ids.into_iter().collect();
     // Collect local user IDs that we need to query
     let keys: Vec<i32> = ids.iter().filter_map(Option::as_ref).copied().collect();

--- a/src/identity/backends/sql/password.rs
+++ b/src/identity/backends/sql/password.rs
@@ -13,8 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chrono::{DateTime, Local, Utc};
-use sea_orm::entity::*;
 use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
 
 use crate::db::entity::password;
 use crate::identity::backends::error::IdentityDatabaseError;

--- a/src/identity/backends/sql/user.rs
+++ b/src/identity/backends/sql/user.rs
@@ -13,8 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chrono::Local;
-use sea_orm::entity::*;
 use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
 
 use crate::config::Config;
 use crate::db::entity::{prelude::User as DbUser, user};

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -13,12 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use sea_orm::DatabaseConnection;
 #[cfg(test)]
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use mockall::mock;
+use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 pub mod backends;
@@ -29,9 +26,10 @@ pub(crate) mod types;
 use crate::config::Config;
 use crate::identity::backends::sql::SqlBackend;
 use crate::identity::error::IdentityProviderError;
-use crate::identity::types::IdentityBackend;
-use crate::identity::types::{Group, GroupCreate, GroupListParameters};
-use crate::identity::types::{User, UserCreate, UserListParameters};
+use crate::identity::types::{
+    IdentityBackend,
+    {Group, GroupCreate, GroupListParameters, User, UserCreate, UserListParameters},
+};
 use crate::plugin_manager::PluginManager;
 
 #[derive(Clone, Debug)]
@@ -47,10 +45,10 @@ pub trait IdentityApi: Send + Sync + Clone {
         params: &UserListParameters,
     ) -> Result<impl IntoIterator<Item = User>, IdentityProviderError>;
 
-    async fn get_user<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn get_user(
         &self,
         db: &DatabaseConnection,
-        user_id: S,
+        user_id: String,
     ) -> Result<Option<User>, IdentityProviderError>;
 
     async fn create_user(
@@ -59,10 +57,10 @@ pub trait IdentityApi: Send + Sync + Clone {
         user: UserCreate,
     ) -> Result<User, IdentityProviderError>;
 
-    async fn delete_user<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn delete_user(
         &self,
         db: &DatabaseConnection,
-        user_id: S,
+        user_id: String,
     ) -> Result<(), IdentityProviderError>;
 
     async fn list_groups(
@@ -71,10 +69,10 @@ pub trait IdentityApi: Send + Sync + Clone {
         params: &GroupListParameters,
     ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError>;
 
-    async fn get_group<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn get_group(
         &self,
         db: &DatabaseConnection,
-        group_id: S,
+        group_id: String,
     ) -> Result<Option<Group>, IdentityProviderError>;
 
     async fn create_group(
@@ -83,11 +81,74 @@ pub trait IdentityApi: Send + Sync + Clone {
         group: GroupCreate,
     ) -> Result<Group, IdentityProviderError>;
 
-    async fn delete_group<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn delete_group(
         &self,
         db: &DatabaseConnection,
-        group_id: S,
+        group_id: String,
     ) -> Result<(), IdentityProviderError>;
+}
+
+#[cfg(test)]
+mock! {
+    pub IdentityProvider {
+        pub fn new(cfg: &Config, plugin_manager: &PluginManager) -> Result<Self, IdentityProviderError>;
+    }
+
+    #[async_trait]
+    impl IdentityApi for IdentityProvider {
+       async fn list_users(
+           &self,
+           db: &DatabaseConnection,
+           params: &UserListParameters,
+       ) -> Result<Vec<User>, IdentityProviderError>;
+
+       async fn get_user(
+           &self,
+           db: &DatabaseConnection,
+           user_id: String,
+       ) -> Result<Option<User>, IdentityProviderError>;
+
+       async fn create_user(
+           &self,
+           db: &DatabaseConnection,
+           user: UserCreate,
+       ) -> Result<User, IdentityProviderError>;
+
+       async fn delete_user(
+           &self,
+           db: &DatabaseConnection,
+           user_id: String,
+       ) -> Result<(), IdentityProviderError>;
+
+       async fn list_groups(
+           &self,
+           db: &DatabaseConnection,
+           params: &GroupListParameters,
+       ) -> Result<Vec<Group>, IdentityProviderError>;
+
+       async fn get_group(
+           &self,
+           db: &DatabaseConnection,
+           group_id: String,
+       ) -> Result<Option<Group>, IdentityProviderError>;
+
+       async fn create_group(
+           &self,
+           db: &DatabaseConnection,
+           group: GroupCreate,
+       ) -> Result<Group, IdentityProviderError>;
+
+       async fn delete_group(
+           &self,
+           db: &DatabaseConnection,
+           group_id: String,
+       ) -> Result<(), IdentityProviderError>;
+    }
+
+    impl Clone for IdentityProvider {
+        fn clone(&self) -> Self;
+    }
+
 }
 
 impl IdentityProvider {
@@ -128,14 +189,12 @@ impl IdentityApi for IdentityProvider {
 
     /// Get single user
     #[tracing::instrument(level = "info", skip(self, db))]
-    async fn get_user<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn get_user(
         &self,
         db: &DatabaseConnection,
-        user_id: S,
+        user_id: String,
     ) -> Result<Option<User>, IdentityProviderError> {
-        self.backend_driver
-            .get_user(db, user_id.as_ref().to_string())
-            .await
+        self.backend_driver.get_user(db, user_id).await
     }
 
     /// Create user
@@ -155,14 +214,12 @@ impl IdentityApi for IdentityProvider {
 
     /// Delete user
     #[tracing::instrument(level = "info", skip(self, db))]
-    async fn delete_user<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn delete_user(
         &self,
         db: &DatabaseConnection,
-        user_id: S,
+        user_id: String,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .delete_user(db, user_id.as_ref().to_string())
-            .await
+        self.backend_driver.delete_user(db, user_id).await
     }
 
     /// List groups
@@ -177,14 +234,12 @@ impl IdentityApi for IdentityProvider {
 
     /// Get single group
     #[tracing::instrument(level = "info", skip(self, db))]
-    async fn get_group<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn get_group(
         &self,
         db: &DatabaseConnection,
-        group_id: S,
+        group_id: String,
     ) -> Result<Option<Group>, IdentityProviderError> {
-        self.backend_driver
-            .get_group(db, group_id.as_ref().to_string())
-            .await
+        self.backend_driver.get_group(db, group_id).await
     }
 
     /// Create group
@@ -195,164 +250,17 @@ impl IdentityApi for IdentityProvider {
         group: GroupCreate,
     ) -> Result<Group, IdentityProviderError> {
         let mut res = group;
-        res.id = Uuid::new_v4().into();
+        res.id = Some(Uuid::new_v4().into());
         self.backend_driver.create_group(db, res).await
     }
 
     /// Delete group
     #[tracing::instrument(level = "info", skip(self, db))]
-    async fn delete_group<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
+    async fn delete_group(
         &self,
         db: &DatabaseConnection,
-        group_id: S,
+        group_id: String,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .delete_group(db, group_id.as_ref().to_string())
-            .await
-    }
-}
-
-#[cfg(test)]
-#[derive(Clone, Debug, Default)]
-pub(crate) struct FakeIdentityProvider {
-    users: Arc<Mutex<HashMap<String, User>>>,
-    groups: Arc<Mutex<HashMap<String, Group>>>,
-}
-
-#[cfg(test)]
-impl From<UserCreate> for User {
-    fn from(value: UserCreate) -> Self {
-        Self {
-            id: value.id,
-            name: value.name,
-            domain_id: value.domain_id,
-            ..Default::default()
-        }
-    }
-}
-#[cfg(test)]
-impl From<GroupCreate> for Group {
-    fn from(value: GroupCreate) -> Self {
-        Self {
-            id: value.id,
-            name: value.name,
-            domain_id: value.domain_id,
-            ..Default::default()
-        }
-    }
-}
-
-#[cfg(test)]
-#[async_trait]
-impl IdentityApi for FakeIdentityProvider {
-    /// List users
-    async fn list_users(
-        &self,
-        _db: &DatabaseConnection,
-        _params: &types::UserListParameters,
-    ) -> Result<impl IntoIterator<Item = User>, IdentityProviderError> {
-        Ok(self
-            .users
-            .lock()
-            .unwrap()
-            .values()
-            .cloned()
-            .collect::<Vec<_>>())
-    }
-
-    /// Get single user
-    async fn get_user<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
-        &self,
-        _db: &DatabaseConnection,
-        user_id: S,
-    ) -> Result<Option<User>, IdentityProviderError> {
-        Ok(self.users.lock().unwrap().get(user_id.as_ref()).cloned())
-    }
-
-    /// Create user
-    async fn create_user(
-        &self,
-        _db: &DatabaseConnection,
-        user: UserCreate,
-    ) -> Result<User, IdentityProviderError> {
-        let mut mod_user = user;
-        mod_user.id = Uuid::new_v4().into();
-        let res = User::from(mod_user);
-        self.users
-            .lock()
-            .unwrap()
-            .insert(res.id.clone(), res.clone());
-        Ok(res)
-    }
-
-    /// Delete user
-    async fn delete_user<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
-        &self,
-        _db: &DatabaseConnection,
-        user_id: S,
-    ) -> Result<(), IdentityProviderError> {
-        Ok(self
-            .users
-            .lock()
-            .unwrap()
-            .remove(user_id.as_ref())
-            .map(|_| ())
-            .ok_or(IdentityProviderError::UserNotFound(
-                user_id.as_ref().to_string(),
-            ))?)
-    }
-
-    async fn list_groups(
-        &self,
-        _db: &DatabaseConnection,
-        _params: &GroupListParameters,
-    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError> {
-        Ok(self
-            .groups
-            .lock()
-            .unwrap()
-            .values()
-            .cloned()
-            .collect::<Vec<_>>())
-    }
-
-    /// Get single user
-    async fn get_group<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
-        &self,
-        _db: &DatabaseConnection,
-        group_id: S,
-    ) -> Result<Option<Group>, IdentityProviderError> {
-        Ok(self.groups.lock().unwrap().get(group_id.as_ref()).cloned())
-    }
-
-    /// Create group
-    async fn create_group(
-        &self,
-        _db: &DatabaseConnection,
-        group: GroupCreate,
-    ) -> Result<Group, IdentityProviderError> {
-        let mut req = group;
-        req.id = Uuid::new_v4().into();
-        let res = Group::from(req);
-        self.groups
-            .lock()
-            .unwrap()
-            .insert(res.id.clone(), res.clone());
-        Ok(res)
-    }
-    ///
-    /// Delete group
-    async fn delete_group<S: AsRef<str> + std::fmt::Debug + Send + Sync>(
-        &self,
-        _db: &DatabaseConnection,
-        id: S,
-    ) -> Result<(), IdentityProviderError> {
-        Ok(self
-            .groups
-            .lock()
-            .unwrap()
-            .remove(id.as_ref())
-            .map(|_| ())
-            .ok_or(IdentityProviderError::UserNotFound(id.as_ref().to_string()))?)
+        self.backend_driver.delete_group(db, group_id).await
     }
 }

--- a/src/identity/types/group.rs
+++ b/src/identity/types/group.rs
@@ -32,7 +32,7 @@ pub struct Group {
     pub name: String,
 }
 
-#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[builder(setter(strip_option, into))]
 pub struct GroupListParameters {
     /// Filter groups by the domain
@@ -41,7 +41,7 @@ pub struct GroupListParameters {
     pub name: Option<String>,
 }
 
-#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[builder(setter(strip_option, into))]
 pub struct GroupCreate {
     /// The description of the group.
@@ -52,7 +52,7 @@ pub struct GroupCreate {
     #[builder(default)]
     pub extra: Option<Value>,
     /// The ID of the group.
-    pub id: String,
+    pub id: Option<String>,
     /// The user name. Must be unique within the owning domain.
     pub name: String,
 }

--- a/src/identity/types/user.rs
+++ b/src/identity/types/user.rs
@@ -140,7 +140,7 @@ pub struct FederationProtocol {
     pub unique_id: String,
 }
 
-#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct UserListParameters {
     /// Filter users by the domain
     pub domain_id: Option<String>,

--- a/src/keystone.rs
+++ b/src/keystone.rs
@@ -12,9 +12,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::extract::FromRef;
 use sea_orm::DatabaseConnection;
-//use tokio::sync::RwLock;
-
+use std::sync::Arc;
 use tracing::info;
 
 use crate::config::Config;
@@ -24,17 +24,22 @@ use crate::provider::Provider;
 // Placing ServiceState behind Arc is necessary to address DatabaseConnection not implementing
 // Clone
 //#[derive(Clone)]
-pub struct ServiceState<P> {
+#[derive(FromRef)]
+pub struct Service {
     pub config: Config,
-    pub provider: P,
+    pub provider: Provider,
+    #[from_ref(skip)]
     pub db: DatabaseConnection,
 }
 
-impl<P> ServiceState<P>
-where
-    P: Provider,
-{
-    pub fn new(cfg: Config, db: DatabaseConnection, provider: P) -> Result<Self, KeystoneError> {
+pub type ServiceState = Arc<Service>;
+
+impl Service {
+    pub fn new(
+        cfg: Config,
+        db: DatabaseConnection,
+        provider: Provider,
+    ) -> Result<Self, KeystoneError> {
         Ok(Self {
             config: cfg.clone(),
             provider,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,4 @@ pub mod resource;
 pub mod token;
 
 #[cfg(test)]
-mod tests {}
+mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,15 +12,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use utoipa_axum::router::OpenApiRouter;
-
-use crate::keystone::ServiceState;
-
-pub mod group;
-pub mod user;
-
-pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
-    OpenApiRouter::new()
-        .nest("/users", user::openapi_router())
-        .nest("/groups", group::openapi_router())
-}
+pub(crate) mod api;

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::identity::MockIdentityProvider;
+use crate::keystone::{Service, ServiceState};
+use crate::provider::ProviderBuilder;
+use crate::token::{MockTokenProvider, Token, TokenProviderError};
+
+pub(crate) fn get_mocked_state_unauthed() -> ServiceState {
+    let db = DatabaseConnection::Disconnected;
+    let config = Config::default();
+    let identity_mock = MockIdentityProvider::default();
+    let mut token_mock = MockTokenProvider::default();
+    token_mock
+        .expect_validate_token()
+        .returning(|_, _| Err(TokenProviderError::InvalidToken));
+
+    let provider = ProviderBuilder::default()
+        .config(config.clone())
+        .identity(identity_mock)
+        .token(token_mock)
+        .build()
+        .unwrap();
+
+    Arc::new(Service::new(config, db, provider).unwrap())
+}
+
+pub(crate) fn get_mocked_state(identity_mock: MockIdentityProvider) -> ServiceState {
+    let db = DatabaseConnection::Disconnected;
+    let config = Config::default();
+    let mut token_mock = MockTokenProvider::default();
+    token_mock
+        .expect_validate_token()
+        .returning(|_, _| Ok(Token::default()));
+
+    let provider = ProviderBuilder::default()
+        .config(config.clone())
+        .identity(identity_mock)
+        .token(token_mock)
+        .build()
+        .unwrap();
+
+    Arc::new(Service::new(config, db, provider).unwrap())
+}

--- a/src/token/fernet_utils.rs
+++ b/src/token/fernet_utils.rs
@@ -30,7 +30,9 @@ impl FernetUtils {
         Ok(self.key_repository.exists())
     }
 
-    pub fn load_keys(&self) -> Result<impl IntoIterator<Item = String>, TokenProviderError> {
+    pub fn load_keys(
+        &self,
+    ) -> Result<impl IntoIterator<Item = String> + use<>, TokenProviderError> {
         let mut keys: BTreeMap<i8, String> = BTreeMap::new();
         if self.validate_key_repository()? {
             for entry in fs::read_dir(&self.key_repository)? {
@@ -49,7 +51,7 @@ impl FernetUtils {
     }
     pub async fn load_keys_async(
         &self,
-    ) -> Result<impl IntoIterator<Item = String>, TokenProviderError> {
+    ) -> Result<impl IntoIterator<Item = String> + use<>, TokenProviderError> {
         let mut keys: BTreeMap<i8, String> = BTreeMap::new();
         if self.validate_key_repository()? {
             let mut entries = fs_async::read_dir(&self.key_repository).await?;

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -14,6 +14,8 @@
 
 use async_trait::async_trait;
 use chrono::{Local, TimeDelta};
+#[cfg(test)]
+use mockall::mock;
 
 mod error;
 pub mod fernet;
@@ -75,22 +77,22 @@ impl TokenApi for TokenProvider {
 }
 
 #[cfg(test)]
-#[derive(Clone, Debug, Default)]
-pub(crate) struct FakeTokenProvider {}
-
-#[cfg(test)]
-#[async_trait]
-impl TokenApi for FakeTokenProvider {
-    /// Validate token
-    #[tracing::instrument(level = "info", skip(self))]
-    async fn validate_token(
-        &self,
-        _credential: String,
-        _window_seconds: Option<i64>,
-    ) -> Result<Token, TokenProviderError> {
-        Ok(Token {
-            user_id: String::new(),
-            ..Default::default()
-        })
+mock! {
+    pub TokenProvider {
+        pub fn new(cfg: &Config) -> Result<Self, TokenProviderError>;
     }
+
+    #[async_trait]
+    impl TokenApi for TokenProvider {
+        async fn validate_token(
+            &self,
+            credential: String,
+            window_seconds: Option<i64>,
+        ) -> Result<Token, TokenProviderError>;
+    }
+
+    impl Clone for TokenProvider {
+        fn clone(&self) -> Self;
+    }
+
 }


### PR DESCRIPTION
- add required auth to all necessary methods
- implement mocks for provider

Since some Keystone endpoints have different auth requirements it cannot
be handled in the middleware and should be instead processed with
extractors. Access to the state from extractor is not supporting state
with generics. Due to that it is required to again rework the state, but
now we finally have the proper mock support.
