### PR TITLE
chore: Build custom keycloak image

### DIFF
--- a/.github/workflows/build-keycloak-image.yml
+++ b/.github/workflows/build-keycloak-image.yml
@@ -1,0 +1,33 @@
+name: Build and Push Keycloak Service Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/Dockerfile.keycloak' # Trigger build only when Dockerfile changes
+  workflow_dispatch: # Allows manual trigger
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub (or GHCR)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: gtema
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Keycloak image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tools/keycloak.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/gtema/keycloak-ci-service:latest@26.2
+            ghcr.io/gtema/keycloak-ci-service:${{ github.sha }}

--- a/tools/Dockerfile.keycloak
+++ b/tools/Dockerfile.keycloak
@@ -1,0 +1,2 @@
+FROM quay.io/keycloak/keycloak:26.2
+CMD ["start-dev"]


### PR DESCRIPTION
It is necessary to have a keycloak container that is able to start as a
service.
