### PR TITLE
chore: Move wasm policy behind the feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2131,7 +2131,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2332,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -3524,7 +3524,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3561,7 +3561,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4602,6 +4602,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5166,7 +5176,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ eyre = { version = "0.6" }
 fernet = { version = "0.2" }
 futures-util = { version = "0.3" }
 mockall_double = { version = "0.3" }
-opa-wasm = { version = "^0.1" }
+opa-wasm = { version = "^0.1", optional = true }
 openidconnect = { version = "4.0" }
 regex = { version = "1.11"}
 reqwest = { version = "0.12", features = ["json"] }
@@ -76,6 +76,10 @@ tempfile = { version = "3.20" }
 thirtyfour = "0.36.0"
 tracing-test = { version = "0.2" }
 url = { version = "2.5" }
+
+[features]
+default = []
+wasm = ["dep:opa-wasm"]
 
 [profile.release]
 strip = true

--- a/doc/src/policy.md
+++ b/doc/src/policy.md
@@ -24,7 +24,8 @@ crate happening for the big policy files. The investigation is in progress, so
 it is preferred not to rely on this method anyway. While running OPA as a WASM
 eliminates any networking communication, it heavily reduces feature set. In
 particular hot policy reload, decision logging, external calls done by the
-policies themselves are not possible by design.
+policies themselves are not possible by design. Using this way of policy
+enforcement requires `wasm` feature enabled.
 
 All the policies currently are using the same policy names and definitions as
 the original Keystone to keep the deviation as less as possible. For the newly

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,10 @@ pub enum KeystoneError {
         source: PolicyError,
     },
 
+    /// Policy engine is not available.
+    #[error("policy enforcement is requested, but not available with the enabled features")]
+    PolicyEnforcementNotAvailable,
+
     #[error(transparent)]
     ResourceError {
         #[from]


### PR DESCRIPTION
Since wasm is now not the preferred way of policy enforcement hide it
behind the not default feature flag - user must explicitly understand
the consequences.
