### PR TITLE
feat: Allow dumping OpenAPI directly from bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,32 @@ jobs:
 
       - name: Run Doc tests
         run: cargo test --doc
+
+  openapi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+
+      - name: Generate OpenAPI
+        run: cargo run --bin keystone -- --dump-openapi yaml > openapi.yaml
+
+      - name: Upload OpenAPI spec
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: openapi.spec
+          path: openapi.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,6 +4407,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.10.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,6 +5523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,6 +5573,7 @@ dependencies = [
  "indexmap 2.10.0",
  "serde",
  "serde_json",
+ "serde_norway",
  "utoipa-gen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tower-http = { version = "0.6", features = ["compression-full", "request-id", "s
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [] }
 url = { version = "2.5", features = ["serde"] }
-utoipa = { version = "5.4", features = ["axum_extras", "chrono"] }
+utoipa = { version = "5.4", features = ["axum_extras", "chrono", "yaml"] }
 utoipa-axum = { version = "0.2" }
 utoipa-swagger-ui = { version = "9.0", features = ["axum", "vendored"], default-features = false }
 uuid = { version = "1.17", features = ["v4"] }


### PR DESCRIPTION
Allow dumping the OpenAPI spec directly from keystone executable instead
of starting it.
