### PR TITLE
feat: Allow policy to list all IdP

### DIFF
--- a/policy/federation/idp/identity_provider_list.rego
+++ b/policy/federation/idp/identity_provider_list.rego
@@ -6,6 +6,12 @@ import data.identity
 
 default allow := false
 
+default can_see_other_domain_resources := false
+
+can_see_other_domain_resources := true if {
+	"admin" in input.credentials.roles
+}
+
 allow if {
 	identity.own_idp
 	"reader" in input.credentials.roles

--- a/src/api/v4/federation/identity_provider/create.rs
+++ b/src/api/v4/federation/identity_provider/create.rs
@@ -107,7 +107,7 @@ mod tests {
                 })
             });
 
-        let state = get_mocked_state(federation_mock, true);
+        let state = get_mocked_state(federation_mock, true, None);
 
         let mut api = openapi_router()
             .layer(TraceLayer::new_for_http())

--- a/src/api/v4/federation/identity_provider/delete.rs
+++ b/src/api/v4/federation/identity_provider/delete.rs
@@ -143,7 +143,7 @@ mod tests {
             .withf(|_: &DatabaseConnection, id: &'_ str| id == "bar")
             .returning(|_, _| Ok(()));
 
-        let state = get_mocked_state(federation_mock, true);
+        let state = get_mocked_state(federation_mock, true, None);
 
         let mut api = openapi_router()
             .layer(TraceLayer::new_for_http())

--- a/src/api/v4/federation/identity_provider/show.rs
+++ b/src/api/v4/federation/identity_provider/show.rs
@@ -121,7 +121,7 @@ mod tests {
                 }))
             });
 
-        let state = get_mocked_state(federation_mock, true);
+        let state = get_mocked_state(federation_mock, true, None);
 
         let mut api = openapi_router()
             .layer(TraceLayer::new_for_http())
@@ -193,7 +193,7 @@ mod tests {
                 }))
             });
 
-        let state = get_mocked_state(federation_mock, false);
+        let state = get_mocked_state(federation_mock, false, None);
 
         let mut api = openapi_router()
             .layer(TraceLayer::new_for_http())

--- a/src/api/v4/federation/identity_provider/update.rs
+++ b/src/api/v4/federation/identity_provider/update.rs
@@ -135,7 +135,7 @@ mod tests {
                 })
             });
 
-        let state = get_mocked_state(federation_mock, true);
+        let state = get_mocked_state(federation_mock, true, None);
 
         let mut api = openapi_router()
             .layer(TraceLayer::new_for_http())

--- a/src/api/v4/federation/types/identity_provider.rs
+++ b/src/api/v4/federation/types/identity_provider.rs
@@ -357,7 +357,7 @@ impl TryFrom<IdentityProviderListParameters> for types::IdentityProviderListPara
     fn try_from(value: IdentityProviderListParameters) -> Result<Self, Self::Error> {
         Ok(Self {
             name: value.name,
-            domain_id: value.domain_id,
+            domain_ids: None, //value.domain_id,
         })
     }
 }

--- a/src/federation/types/identity_provider.rs
+++ b/src/federation/types/identity_provider.rs
@@ -101,6 +101,7 @@ pub struct IdentityProviderUpdate {
 pub struct IdentityProviderListParameters {
     /// Filters the response by IDP name.
     pub name: Option<String>,
-    /// Filters the response by a domain_id ID.
-    pub domain_id: Option<String>,
+    /// Filters the response by a domain_id ID. It is an optional list of optional strings to
+    /// represent fetching of null and non-null values in a single request.
+    pub domain_ids: Option<std::collections::HashSet<Option<String>>>,
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -296,6 +296,7 @@ impl Policy {
             debug!("not enforcing policy due to the absence of initialized WASM data");
             PolicyEvaluationResult {
                 allow: true,
+                can_see_other_domain_resources: None,
                 violations: None,
             }
         };
@@ -326,7 +327,12 @@ pub struct OpaResponse {
 /// The result of a policy evaluation.
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct PolicyEvaluationResult {
+    /// Whether the user is allowed to perform the request or not.
     pub allow: bool,
+    /// Whether the user is allowed to see resources of other domains.
+    #[serde(default)]
+    pub can_see_other_domain_resources: Option<bool>,
+    /// List of violations.
     #[serde(rename = "violation")]
     pub violations: Option<Vec<Violation>>,
 }
@@ -367,6 +373,16 @@ impl PolicyEvaluationResult {
     pub fn allowed() -> Self {
         Self {
             allow: true,
+            can_see_other_domain_resources: None,
+            violations: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn allowed_admin() -> Self {
+        Self {
+            allow: true,
+            can_see_other_domain_resources: Some(true),
             violations: None,
         }
     }
@@ -375,6 +391,7 @@ impl PolicyEvaluationResult {
     pub fn forbidden() -> Self {
         Self {
             allow: false,
+            can_see_other_domain_resources: Some(false),
             violations: None,
         }
     }

--- a/src/token/error.rs
+++ b/src/token/error.rs
@@ -161,6 +161,13 @@ pub enum TokenProviderError {
     },
 
     #[error(transparent)]
+    IndentityProvider {
+        /// The source of the error.
+        #[from]
+        source: crate::identity::error::IdentityProviderError,
+    },
+
+    #[error(transparent)]
     ResourceProvider {
         /// The source of the error.
         #[from]


### PR DESCRIPTION
Extend the policy framework to allow listing of the IDPs not owned by
the user's domain. The policy result is extended with
optional `can_see_other_domain_resources` attribute. When returned and
true IDP filter for domain_id is emtpy, otherwise null and the user
domain.
