### PR TITLE
fix: Improve fernet keys loading

### DIFF
--- a/benches/fernet_token.rs
+++ b/benches/fernet_token.rs
@@ -1,7 +1,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 use openstack_keystone::config::Config;
@@ -19,8 +18,14 @@ fn bench_decrypt_token(c: &mut Criterion) {
     let mut tmp_file = File::create(file_path).unwrap();
     write!(tmp_file, "BFTs1CIVIBLTP4GOrQ26VETrJ7Zwz1O4wbEcCQ966eM=").unwrap();
 
+    let builder = config::Config::builder()
+        .set_override("auth.methods", "password,token")
+        .unwrap()
+        .set_override("database.connection", "dummy")
+        .unwrap();
+    let mut config: Config = Config::try_from(builder).expect("can build a valid config");
     let mut backend = FernetTokenProvider::default();
-    let mut config = Config::new(PathBuf::new()).unwrap();
+
     config.fernet_tokens.key_repository = tmp_dir.keep();
     backend.set_config(config);
     backend.load_keys().unwrap();

--- a/src/identity/password_hashing.rs
+++ b/src/identity/password_hashing.rs
@@ -61,7 +61,6 @@ pub fn verify_password<P: AsRef<[u8]>, H: AsRef<str>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn test_verify_length_and_trunc_password() {
@@ -82,7 +81,12 @@ mod tests {
 
     #[test]
     fn test_hash_bcrypt() {
-        let conf = Config::new(PathBuf::new()).unwrap();
+        let builder = config::Config::builder()
+            .set_override("auth.methods", "")
+            .unwrap()
+            .set_override("database.connection", "dummy")
+            .unwrap();
+        let conf: Config = Config::try_from(builder).expect("can build a valid config");
         assert!(hash_password(&conf, "abcdefg").is_ok());
     }
 }

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -14,7 +14,6 @@
 
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 use crate::config::Config;
@@ -23,15 +22,18 @@ pub fn setup_config() -> Config {
     let keys_dir = tempdir().unwrap();
     // write fernet key used to generate tokens in python
     let file_path = keys_dir.path().join("0");
-    let mut tmp_file = File::create(file_path).unwrap();
+    let mut tmp_file = File::create(&file_path).unwrap();
     write!(tmp_file, "BFTs1CIVIBLTP4GOrQ26VETrJ7Zwz1O4wbEcCQ966eM=").unwrap();
-    let mut config = Config::new(PathBuf::new()).unwrap();
+
+    let builder = config::Config::builder()
+        .set_override(
+            "auth.methods",
+            "password,token,openid,application_credential",
+        )
+        .unwrap()
+        .set_override("database.connection", "dummy")
+        .unwrap();
+    let mut config: Config = Config::try_from(builder).expect("can build a valid config");
     config.fernet_tokens.key_repository = keys_dir.keep();
-    config.auth.methods = vec![
-        "password".into(),
-        "token".into(),
-        "openid".into(),
-        "application_credential".into(),
-    ];
     config
 }

--- a/src/token/error.rs
+++ b/src/token/error.rs
@@ -46,7 +46,7 @@ pub enum TokenProviderError {
     },
 
     /// Missing fernet keys
-    #[error("missing fernet keys")]
+    #[error("no usable fernet keys has been found")]
     FernetKeysMissing,
 
     /// Invalid token data


### PR DESCRIPTION
- trim trailing line breaks, as those are making keys invalid.
- raise explicit exception when no usable keys has been found.
- log warning when a key file was not considered usable.

Irrelevant: make config.auth section mandatory

Since without specifying auth.methods the whole thing is not able to
work make the section non-default.
