### PR TITLE
fix: Ensure linters job run when necessary

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,10 +9,6 @@ on:
     branches: ["main" ]
   pull_request:
     branches: ["main" ]
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/linters.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -40,8 +36,6 @@ jobs:
           toolchain: ${{ env.rust_min }}
           components: rustfmt
 
-      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-
       - name: Run rustfmt
         run: cargo fmt -- --check
 
@@ -65,8 +59,6 @@ jobs:
         with:
           toolchain: ${{ env.rust_min }}
           components: rustfmt, clippy
-
-      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@9ba3ac3fd006a70c6e186a683577abc1ccf0ff3a # v2.54.0

--- a/src/api/v4/token/restriction/show.rs
+++ b/src/api/v4/token/restriction/show.rs
@@ -33,7 +33,7 @@ use crate::token::TokenApi;
 #[utoipa::path(
     get,
     path = "/{id}",
-    operation_id = "/token_restiction:show",
+    operation_id = "/token_restriction:show",
     params(
       ("id" = String, Path, description = "The ID of the token restriction")
     ),


### PR DESCRIPTION
Due to an error in the workflow it mostly only run after merge (too
late).
