### PR TITLE
feat: Parallelize few user listing subqueries

### DIFF
--- a/src/identity/backends/error.rs
+++ b/src/identity/backends/error.rs
@@ -35,6 +35,12 @@ pub enum IdentityDatabaseError {
         source: serde_json::Error,
     },
 
+    #[error(transparent)]
+    Join {
+        #[from]
+        source: tokio::task::JoinError,
+    },
+
     #[error("building user response data")]
     UserBuilderError {
         #[from]


### PR DESCRIPTION
use tokio::join to start some of the user(s) listing queries in
parallel.
