### PR TITLE
chore: Adapt docs and workflows for the new org

### DIFF
--- a/.github/workflows/build-keycloak-image.yml
+++ b/.github/workflows/build-keycloak-image.yml
@@ -1,4 +1,9 @@
 name: Build and Push Keycloak Service Image
+# This workflow is necessary to build a Keycloak image with an entry point since
+# GitHub actions are not allowing to specify the image command and Keycloak
+# image not having a default one. It could be avoided with the direct call to
+# docker to start container, but this is also a way and keeps the image close to
+# the place where it is necessary causing less network traffic.
 
 on:
   push:
@@ -6,6 +11,12 @@ on:
       - main
     paths:
       - 'tools/Dockerfile.keycloak' # Trigger build only when Dockerfile changes
+      - '.github/workflows/build-keycloak-image.yml'
+  pull_request:
+    branches: ["main" ]
+    paths:
+      - 'tools/Dockerfile.keycloak' # Trigger build only when Dockerfile changes
+      - '.github/workflows/build-keycloak-image.yml'
   workflow_dispatch: # Allows manual trigger
 
 jobs:
@@ -22,7 +33,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: gtema
+          username: openstack-experimental
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Keycloak image
@@ -32,5 +43,5 @@ jobs:
           file: tools/Dockerfile.keycloak
           push: true
           tags: |
-            ghcr.io/gtema/keystone/keycloak-ci-service:26.2
-            ghcr.io/gtema/keystone/keycloak-ci-service:${{ github.sha }}
+            ghcr.io/openstack-experimental/keystone/keycloak-ci-service:26.2
+            ghcr.io/openstack-experimental/keystone/keycloak-ci-service:${{ github.sha }}

--- a/.github/workflows/build-keystone-py-image.yml
+++ b/.github/workflows/build-keystone-py-image.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch: # Allows manual trigger
 
 env:
-  REGISTRY_IMAGE: ghcr.io/gtema/keystone/py-keystone
+  REGISTRY_IMAGE: ghcr.io/openstack-experimental/keystone/py-keystone
 
 permissions:
   contents: read
@@ -53,7 +53,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: gtema
+          username: openstack-experimental
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
@@ -103,7 +103,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: gtema
+          username: openstack-experimental
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -147,7 +147,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       keycloak:
-        image: ghcr.io/gtema/keystone/keycloak-ci-service:26.2
+        image: ghcr.io/openstack-experimental/keystone/keycloak-ci-service:26.2
         env:
           KC_BOOTSTRAP_ADMIN_USERNAME: admin
           KC_BOOTSTRAP_ADMIN_PASSWORD: password
@@ -186,7 +186,7 @@ jobs:
       - name: Run github tests
         env:
           GITHUB_JWT: ${{ steps.get_token.outputs.token }}
-          GITHUB_SUB: "repo:gtema/keystone:pull_request"
+          GITHUB_SUB: "repo:openstack-experimental/keystone:pull_request"
         run: cargo test --test github -- --nocapture
 
       - name: Dump seleniumdriver log

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # OpenStack Keystone in Rust
 
-Attempt to provide Rust library for OpenStack Keystone functionality by
-implementing database access in the same way as Keystone does. When the concept
-proves usability this might become a base for reimplementing Keystone in Rust.
+Successor to the OpenStack Keystone written in Rust.
+
+This project aims at implementing OpenStack Identity service using the Rust as
+the programming language. It focuses on implementing v4 API, while certain set
+of the v3 API is also going to be implemented making transition easier.
+
+As of now it can be easily deployed in parallel to the python Keystone just by
+forwarding v3 APIs to the python Keystone and v4 APIs to the rust
+implementation.
 
 ## Config
 
@@ -20,13 +26,17 @@ Sea-ORM is being used to access database. PostgreSQL and MySQL are supported.
 
 ## Load test
 
-A very brief load test is implemented in `loadtest` using `Goose` framework. It
-generates test load by first incrementally increasing requests up to the
+A very brief load test is implemented in `loadtest` using `Goose` framework.
+It generates test load by first incrementally increasing requests up to the
 configured amount (defaults to count of the cpu cores), keeps the load for the
-configured amount of time while measuring the response latency and the throughput (RPS).
+configured amount of time while measuring the response latency and the
+throughput (RPS).
 
-For every PR load test suite is being executed. It is absolutely clear that the Rust implementation currently misses certain things original Keystone doe, but the gap is being closed over the time. However test shows
-difference of factor **10-100** which is already remarkable. New tests will appear to have a more thorough coverage of the exposed API.
+For every PR load test suite is being executed. It is absolutely clear that the
+Rust implementation currently misses certain things original Keystone doe, but
+the gap is being closed over the time. However test shows difference of factor 
+**10-100** which is already remarkable. New tests will appear to have a more
+thorough coverage of the exposed API.
 
 ## Trying
 
@@ -44,3 +54,4 @@ Comprehensive (as much as it can be at the current stage) is available
 
 Detailed introduction of the project was given as
 [ALASCA tech talk](https://www.youtube.com/watch?v=0Hx4Q22ZNFU).
+[OpenStack Summit 2025](https://www.youtube.com/watch?v=XOHYqE2HRw4&list=PLKqaoAnDyfgr91wN_12nwY321504Ctw1s&index=30)

--- a/doc/src/install.md
+++ b/doc/src/install.md
@@ -59,7 +59,7 @@ done.
 
 ```console
 
-docker run -v /etc/keystone/:/etc/keystone -p 8080:8080 ghcr.io/gtema/keystone:main -v /etc/keystone/keystone.conf
+docker run -v /etc/keystone/:/etc/keystone -p 8080:8080 ghcr.io/openstack-experimental/keystone:main -v /etc/keystone/keystone.conf
 ```
 
 ## Database migrations


### PR DESCRIPTION
The project has been moved from `gtema` user namespace under the
`openstack-experimental` organization. Make necessary adaptations in
docs and workflows.
