### PR TITLE
feat: Enforce context for DB operations in identity

### DIFF
--- a/src/identity/backends/error.rs
+++ b/src/identity/backends/error.rs
@@ -100,9 +100,3 @@ pub fn db_err(e: sea_orm::DbErr, context: &str) -> IdentityDatabaseError {
         },
     )
 }
-
-impl From<sea_orm::DbErr> for IdentityDatabaseError {
-    fn from(err: sea_orm::DbErr) -> Self {
-        db_err(err, "unknown")
-    }
-}

--- a/src/identity/backends/sql/group/create.rs
+++ b/src/identity/backends/sql/group/create.rs
@@ -18,7 +18,7 @@ use serde_json::json;
 
 use crate::db::entity::group;
 use crate::identity::Config;
-use crate::identity::backends::sql::IdentityDatabaseError;
+use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
 use crate::identity::types::{Group, GroupCreate};
 
 pub async fn create(
@@ -36,7 +36,10 @@ pub async fn create(
         )?)),
     };
 
-    let db_entry: group::Model = entry.insert(db).await?;
+    let db_entry: group::Model = entry
+        .insert(db)
+        .await
+        .map_err(|err| db_err(err, "persisting new group record"))?;
 
     Ok(db_entry.into())
 }

--- a/src/identity/backends/sql/group/delete.rs
+++ b/src/identity/backends/sql/group/delete.rs
@@ -17,14 +17,17 @@ use sea_orm::entity::*;
 
 use crate::db::entity::prelude::Group as DbGroup;
 use crate::identity::Config;
-use crate::identity::backends::sql::IdentityDatabaseError;
+use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
 
 pub async fn delete<S: AsRef<str>>(
     _conf: &Config,
     db: &DatabaseConnection,
     group_id: S,
 ) -> Result<(), IdentityDatabaseError> {
-    let res = DbGroup::delete_by_id(group_id.as_ref()).exec(db).await?;
+    let res = DbGroup::delete_by_id(group_id.as_ref())
+        .exec(db)
+        .await
+        .map_err(|err| db_err(err, "removing group record"))?;
     if res.rows_affected == 1 {
         Ok(())
     } else {

--- a/src/identity/backends/sql/group/get.rs
+++ b/src/identity/backends/sql/group/get.rs
@@ -17,7 +17,7 @@ use sea_orm::entity::*;
 
 use crate::db::entity::prelude::Group as DbGroup;
 use crate::identity::Config;
-use crate::identity::backends::sql::IdentityDatabaseError;
+use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
 use crate::identity::types::Group;
 
 pub async fn get<S: AsRef<str>>(
@@ -27,7 +27,8 @@ pub async fn get<S: AsRef<str>>(
 ) -> Result<Option<Group>, IdentityDatabaseError> {
     Ok(DbGroup::find_by_id(group_id.as_ref())
         .one(db)
-        .await?
+        .await
+        .map_err(|err| db_err(err, "fetching group data"))?
         .map(Into::into))
 }
 

--- a/src/identity/backends/sql/group/list.rs
+++ b/src/identity/backends/sql/group/list.rs
@@ -18,7 +18,7 @@ use sea_orm::query::*;
 
 use crate::db::entity::{group, prelude::Group as DbGroup};
 use crate::identity::Config;
-use crate::identity::backends::sql::IdentityDatabaseError;
+use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
 use crate::identity::types::{Group, GroupListParameters};
 
 pub async fn list(
@@ -36,7 +36,10 @@ pub async fn list(
         group_select = group_select.filter(group::Column::Name.eq(name));
     }
 
-    let db_groups: Vec<group::Model> = group_select.all(db).await?;
+    let db_groups: Vec<group::Model> = group_select
+        .all(db)
+        .await
+        .map_err(|err| db_err(err, "listing groups"))?;
     let results: Vec<Group> = db_groups.into_iter().map(Into::into).collect();
 
     Ok(results)

--- a/src/identity/backends/sql/password.rs
+++ b/src/identity/backends/sql/password.rs
@@ -17,7 +17,7 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::password;
-use crate::identity::backends::error::IdentityDatabaseError;
+use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
 
 pub async fn create<S: AsRef<str>>(
     db: &DatabaseConnection,
@@ -40,6 +40,9 @@ pub async fn create<S: AsRef<str>>(
         entry.expires_at = Set(Some(expire.naive_utc()));
         entry.expires_at_int = Set(Some(expire.timestamp_micros()));
     }
-    let db_entry: password::Model = entry.insert(db).await?;
+    let db_entry: password::Model = entry
+        .insert(db)
+        .await
+        .map_err(|err| db_err(err, "inserting new password record"))?;
     Ok(db_entry)
 }

--- a/src/identity/backends/sql/user_option.rs
+++ b/src/identity/backends/sql/user_option.rs
@@ -17,17 +17,18 @@ use sea_orm::entity::*;
 use sea_orm::query::*;
 
 use crate::db::entity::{prelude::UserOption as DbUserOptions, user_option};
-use crate::identity::backends::sql::IdentityDatabaseError;
+use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
 use crate::identity::types::*;
 
 pub async fn get<S: AsRef<str>>(
     db: &DatabaseConnection,
     user_id: S,
 ) -> Result<impl IntoIterator<Item = user_option::Model>, IdentityDatabaseError> {
-    Ok(DbUserOptions::find()
+    DbUserOptions::find()
         .filter(user_option::Column::UserId.eq(user_id.as_ref()))
         .all(db)
-        .await?)
+        .await
+        .map_err(|err| db_err(err, "fetching options of the user"))
 }
 
 impl FromIterator<user_option::Model> for UserOptions {


### PR DESCRIPTION
Remove From trait implementation for the DB operations in the identity
provider to enforce using the helper method with specifying the context
information. This dramatically improves the error finding since the
error contain the reference to the operation that caused it.
