### PR TITLE
chore: Forbid unsafe code with a global lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,10 @@ name = "functional"
 path = "tests/functional/main.rs"
 test = false
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+enum_glob_use = "deny"


### PR DESCRIPTION
Add a global lint prohibiting use of unsafe code. Luckily we have no
unsafe code anyway.

Fixes: #328
