### PR TITLE
chore: Skip forbidding unwrap in tests

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true


### PR DESCRIPTION
We forbid use of unwrap and expect in the code, but those should be
allowed in tests. Corresponding lint rules are only possible in the
clippy.toml config file (unless touching the code directly).
