### PR TITLE
feat: Add token `issued_at` property

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,4 +60,4 @@ jobs:
           --thresholds-reset \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           --adapter rust_criterion \
-          cargo bench
+          cargo bench --features bench_internals

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -60,4 +60,4 @@ jobs:
           --testbed ${{ matrix.os }} \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           --adapter rust_criterion \
-          cargo bench
+          cargo bench --features bench_internals

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,6 +2916,7 @@ dependencies = [
  "base64 0.22.1",
  "base64urlsafedata",
  "bcrypt",
+ "byteorder",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = { version = "0.1" }
 axum = { version = "0.8", features = ["macros"] }
 base64 = { version = "0.22" }
 bcrypt = { version = "0.17", features = ["alloc"] }
+byteorder = { version = "1.5" }
 bytes = { version = "1.10" }
 chrono = { version = "0.4" }
 clap = { version = "4.5", features = ["derive"] }
@@ -86,6 +87,7 @@ webauthn-rs = { version = "0.5", features = ["danger-credential-internals"] }
 [features]
 default = []
 wasm = ["dep:opa-wasm"]
+bench_internals = []
 
 [profile.release]
 strip = true

--- a/benches/fernet_token.rs
+++ b/benches/fernet_token.rs
@@ -1,10 +1,14 @@
+#![cfg(feature = "bench_internals")]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::fs::File;
+use std::hint::black_box;
 use std::io::Write;
 use tempfile::tempdir;
 
 use openstack_keystone::config::Config;
 use openstack_keystone::token::fernet::FernetTokenProvider;
+use openstack_keystone::token::fernet::bench_get_fernet_timestamp;
 //use openstack_keystone::token::types::TokenBackend;
 
 fn decode(backend: &FernetTokenProvider, token: &str) {
@@ -40,5 +44,17 @@ fn bench_decrypt_token(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benches, bench_decrypt_token);
+fn bench_get_token_issued_at(c: &mut Criterion) {
+    let token = "gAAAAABns2ixy75K_KfoosWLrNNqG6KW8nm3Xzv0_2dOx8ODWH7B8i2g8CncGLO6XBEH_TYLg83P6XoKQ5bU8An8Kqgw9WX3bvmEQXphnwPM6aRAOQUSdVhTlUm_8otDG9BS2rc70Q7pfy57S3_yBgimy-174aKdP8LPusvdHZsQPEJO9pfeXWw";
+
+    c.bench_with_input(
+        BenchmarkId::new("get_fernet_token_timestamp", "project"),
+        &token,
+        |b, s| {
+            b.iter(|| bench_get_fernet_timestamp(black_box(s)));
+        },
+    );
+}
+
+criterion_group!(benches, bench_decrypt_token, bench_get_token_issued_at);
 criterion_main!(benches);

--- a/src/token/application_credential.rs
+++ b/src/token/application_credential.rs
@@ -41,6 +41,8 @@ pub struct ApplicationCredentialPayload {
     pub application_credential_id: String,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
     pub roles: Vec<Role>,

--- a/src/token/domain_scoped.rs
+++ b/src/token/domain_scoped.rs
@@ -40,6 +40,8 @@ pub struct DomainScopePayload {
     pub domain_id: String,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
     pub roles: Option<Vec<Role>>,

--- a/src/token/error.rs
+++ b/src/token/error.rs
@@ -28,6 +28,15 @@ pub enum TokenProviderError {
         source: std::io::Error,
     },
 
+    /// Fernet payload timestamp overflow error.
+    #[error("fernet payload timestamp overflow ({value}): {}", source)]
+    TokenTimestampOverflow {
+        /// Token timestamp.
+        value: u64,
+        /// The source of the error.
+        source: std::num::TryFromIntError,
+    },
+
     /// Fernet key read error.
     #[error("fernet key read error: {}", source)]
     FernetKeyRead {

--- a/src/token/federation_domain_scoped.rs
+++ b/src/token/federation_domain_scoped.rs
@@ -44,6 +44,8 @@ pub struct FederationDomainScopePayload {
     pub group_ids: Vec<String>,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
     pub roles: Option<Vec<Role>>,

--- a/src/token/federation_project_scoped.rs
+++ b/src/token/federation_project_scoped.rs
@@ -44,6 +44,8 @@ pub struct FederationProjectScopePayload {
     pub group_ids: Vec<String>,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
     pub roles: Option<Vec<Role>>,

--- a/src/token/federation_unscoped.rs
+++ b/src/token/federation_unscoped.rs
@@ -41,6 +41,8 @@ pub struct FederationUnscopedPayload {
     pub group_ids: Vec<String>,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
 }
 

--- a/src/token/project_scoped.rs
+++ b/src/token/project_scoped.rs
@@ -40,6 +40,8 @@ pub struct ProjectScopePayload {
     pub project_id: String,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
     pub roles: Option<Vec<Role>>,

--- a/src/token/restricted.rs
+++ b/src/token/restricted.rs
@@ -52,6 +52,8 @@ pub struct RestrictedPayload {
     pub allow_rescope: bool,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
     pub roles: Option<Vec<Role>>,

--- a/src/token/types.rs
+++ b/src/token/types.rs
@@ -71,6 +71,42 @@ impl Token {
         }
     }
 
+    /// Set the `issued_at` property of the token.
+    ///
+    /// An internal method (available only within the module) to set the `issued_at` into the token
+    /// payload.
+    pub(super) fn set_issued_at(&mut self, issued_at: DateTime<Utc>) -> &mut Self {
+        match self {
+            Self::Unscoped(x) => x.issued_at = issued_at,
+            Self::ProjectScope(x) => x.issued_at = issued_at,
+            Self::DomainScope(x) => x.issued_at = issued_at,
+            Self::FederationUnscoped(x) => x.issued_at = issued_at,
+            Self::FederationProjectScope(x) => x.issued_at = issued_at,
+            Self::FederationDomainScope(x) => x.issued_at = issued_at,
+            Self::ApplicationCredential(x) => x.issued_at = issued_at,
+            Self::Restricted(x) => x.issued_at = issued_at,
+        }
+        self
+    }
+
+    /// Get token `issued_at` timestamp.
+    ///
+    /// Returns the UTC timestamp when the token was encoded (part of the Fernet payload and not the
+    /// token payload).
+    pub const fn issued_at(&self) -> &DateTime<Utc> {
+        match self {
+            Self::Unscoped(x) => &x.issued_at,
+            Self::ProjectScope(x) => &x.issued_at,
+            Self::DomainScope(x) => &x.issued_at,
+            Self::FederationUnscoped(x) => &x.issued_at,
+            Self::FederationProjectScope(x) => &x.issued_at,
+            Self::FederationDomainScope(x) => &x.issued_at,
+            Self::ApplicationCredential(x) => &x.issued_at,
+            Self::Restricted(x) => &x.issued_at,
+        }
+    }
+
+    /// Get token expiration timestamp.
     pub const fn expires_at(&self) -> &DateTime<Utc> {
         match self {
             Self::Unscoped(x) => &x.expires_at,

--- a/src/token/unscoped.rs
+++ b/src/token/unscoped.rs
@@ -37,6 +37,8 @@ pub struct UnscopedPayload {
     pub expires_at: DateTime<Utc>,
 
     #[builder(default)]
+    pub issued_at: DateTime<Utc>,
+    #[builder(default)]
     pub user: Option<UserResponse>,
 }
 


### PR DESCRIPTION
`issued_at` property of the token in python Keystone is a timestamp of
the fernet creation (part of the protocol). Due to the absence of the
method in the fernet crate copy the logic (just a few steps) how to
access it from the message (python keystone does it the same way even
the public method exists).
