### PR TITLE
refactor: Start passing `ServiceState` into providers

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -51,7 +51,7 @@ where
         let token = state
             .provider
             .get_token_provider()
-            .validate_token(&state.provider, &state.db, auth_header, Some(false), None)
+            .validate_token(&state, auth_header, Some(false), None)
             .await
             .inspect_err(|e| error!("{:#?}", e))
             .map_err(|_| KeystoneApiError::Unauthorized)?;
@@ -60,7 +60,7 @@ where
         let token = state
             .provider
             .get_token_provider()
-            .expand_token_information(&token, &state.db, &state.provider)
+            .expand_token_information(&state, &token)
             .await?;
 
         Ok(Self(token))

--- a/src/api/v3/role/mod.rs
+++ b/src/api/v3/role/mod.rs
@@ -129,17 +129,15 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     ..Default::default()

--- a/src/api/v3/role_assignment/mod.rs
+++ b/src/api/v3/role_assignment/mod.rs
@@ -99,17 +99,15 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     ..Default::default()
@@ -138,7 +136,7 @@ mod tests {
         let mut assignment_mock = MockAssignmentProvider::default();
         assignment_mock
             .expect_list_role_assignments()
-            .withf(|_: &DatabaseConnection, _: &Provider, _: &RoleAssignmentListParameters| true)
+            .withf(|_, _, _s| true)
             .returning(|_, _, _| {
                 Ok(vec![Assignment {
                     role_id: "role".into(),
@@ -193,16 +191,14 @@ mod tests {
         let mut assignment_mock = MockAssignmentProvider::default();
         assignment_mock
             .expect_list_role_assignments()
-            .withf(
-                |_: &DatabaseConnection, _: &Provider, qp: &RoleAssignmentListParameters| {
-                    RoleAssignmentListParameters {
-                        role_id: Some("role".into()),
-                        user_id: Some("user1".into()),
-                        project_id: Some("project1".into()),
-                        ..Default::default()
-                    } == *qp
-                },
-            )
+            .withf(|_, _, qp: &RoleAssignmentListParameters| {
+                RoleAssignmentListParameters {
+                    role_id: Some("role".into()),
+                    user_id: Some("user1".into()),
+                    project_id: Some("project1".into()),
+                    ..Default::default()
+                } == *qp
+            })
             .returning(|_, _, _| {
                 Ok(vec![Assignment {
                     role_id: "role".into(),
@@ -216,16 +212,14 @@ mod tests {
 
         assignment_mock
             .expect_list_role_assignments()
-            .withf(
-                |_: &DatabaseConnection, _: &Provider, qp: &RoleAssignmentListParameters| {
-                    RoleAssignmentListParameters {
-                        role_id: Some("role".into()),
-                        user_id: Some("user2".into()),
-                        domain_id: Some("domain2".into()),
-                        ..Default::default()
-                    } == *qp
-                },
-            )
+            .withf(|_, _, qp: &RoleAssignmentListParameters| {
+                RoleAssignmentListParameters {
+                    role_id: Some("role".into()),
+                    user_id: Some("user2".into()),
+                    domain_id: Some("domain2".into()),
+                    ..Default::default()
+                } == *qp
+            })
             .returning(|_, _, _| {
                 Ok(vec![Assignment {
                     role_id: "role".into(),
@@ -239,15 +233,13 @@ mod tests {
 
         assignment_mock
             .expect_list_role_assignments()
-            .withf(
-                |_: &DatabaseConnection, _: &Provider, qp: &RoleAssignmentListParameters| {
-                    RoleAssignmentListParameters {
-                        group_id: Some("group3".into()),
-                        project_id: Some("project3".into()),
-                        ..Default::default()
-                    } == *qp
-                },
-            )
+            .withf(|_, _, qp: &RoleAssignmentListParameters| {
+                RoleAssignmentListParameters {
+                    group_id: Some("group3".into()),
+                    project_id: Some("project3".into()),
+                    ..Default::default()
+                } == *qp
+            })
             .returning(|_, _, _| {
                 Ok(vec![Assignment {
                     role_id: "role".into(),

--- a/src/api/v4/federation/identity_provider.rs
+++ b/src/api/v4/federation/identity_provider.rs
@@ -63,17 +63,15 @@ mod tests {
         policy_allowed_see_other_domains: Option<bool>,
     ) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     user: Some(UserResponse {

--- a/src/api/v4/federation/jwt.rs
+++ b/src/api/v4/federation/jwt.rs
@@ -166,7 +166,7 @@ pub async fn login(
         state
             .provider
             .get_token_provider()
-            .get_token_restriction(&state.db, tr_id, true)
+            .get_token_restriction(&state, tr_id, true)
             .await?
     } else {
         None
@@ -316,7 +316,7 @@ pub async fn login(
     token = state
         .provider
         .get_token_provider()
-        .expand_token_information(&token, &state.db, &state.provider)
+        .expand_token_information(&state, &token)
         .await
         .map_err(|_| KeystoneApiError::Forbidden)?;
 

--- a/src/api/v4/federation/mapping.rs
+++ b/src/api/v4/federation/mapping.rs
@@ -56,17 +56,15 @@ mod tests {
         policy_allowed: bool,
     ) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     ..Default::default()

--- a/src/api/v4/federation/oidc.rs
+++ b/src/api/v4/federation/oidc.rs
@@ -123,7 +123,7 @@ pub async fn callback(
         state
             .provider
             .get_token_provider()
-            .get_token_restriction(&state.db, tr_id, true)
+            .get_token_restriction(&state, tr_id, true)
             .await?
     } else {
         None
@@ -306,7 +306,7 @@ pub async fn callback(
     token = state
         .provider
         .get_token_provider()
-        .expand_token_information(&token, &state.db, &state.provider)
+        .expand_token_information(&state, &token)
         .await
         .map_err(|_| KeystoneApiError::Forbidden)?;
 

--- a/src/api/v4/role/mod.rs
+++ b/src/api/v4/role/mod.rs
@@ -58,17 +58,15 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     ..Default::default()
@@ -97,7 +95,7 @@ mod tests {
         let mut assignment_mock = MockAssignmentProvider::default();
         assignment_mock
             .expect_list_roles()
-            .withf(|_: &DatabaseConnection, _: &RoleListParameters| true)
+            .withf(|_, _: &RoleListParameters| true)
             .returning(|_, _| {
                 Ok(vec![Role {
                     id: "1".into(),
@@ -146,7 +144,7 @@ mod tests {
         let mut assignment_mock = MockAssignmentProvider::default();
         assignment_mock
             .expect_list_roles()
-            .withf(|_: &DatabaseConnection, qp: &RoleListParameters| {
+            .withf(|_, qp: &RoleListParameters| {
                 RoleListParameters {
                     domain_id: Some("domain".into()),
                     name: Some("name".into()),
@@ -200,12 +198,12 @@ mod tests {
         let mut assignment_mock = MockAssignmentProvider::default();
         assignment_mock
             .expect_get_role()
-            .withf(|_: &DatabaseConnection, id: &'_ str| id == "foo")
+            .withf(|_, id: &'_ str| id == "foo")
             .returning(|_, _| Ok(None));
 
         assignment_mock
             .expect_get_role()
-            .withf(|_: &DatabaseConnection, id: &'_ str| id == "bar")
+            .withf(|_, id: &'_ str| id == "bar")
             .returning(|_, _| {
                 Ok(Some(Role {
                     id: "bar".into(),

--- a/src/api/v4/role_assignment/mod.rs
+++ b/src/api/v4/role_assignment/mod.rs
@@ -54,17 +54,15 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     ..Default::default()

--- a/src/api/v4/token/restriction.rs
+++ b/src/api/v4/token/restriction.rs
@@ -63,17 +63,15 @@ mod tests {
         policy_allowed: bool,
         policy_allowed_see_other_domains: Option<bool>,
     ) -> ServiceState {
-        token_mock
-            .expect_validate_token()
-            .returning(|_, _, _, _, _| {
-                Ok(Token::Unscoped(UnscopedPayload {
-                    user_id: "bar".into(),
-                    ..Default::default()
-                }))
-            });
+        token_mock.expect_validate_token().returning(|_, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
         token_mock
             .expect_expand_token_information()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     user: Some(UserResponse {

--- a/src/api/v4/token/restriction/list.rs
+++ b/src/api/v4/token/restriction/list.rs
@@ -72,7 +72,7 @@ pub(super) async fn list(
     let token_restrictions: Vec<TokenRestriction> = state
         .provider
         .get_token_provider()
-        .list_token_restrictions(&state.db, &provider_list_params)
+        .list_token_restrictions(&state, &provider_list_params)
         .await?
         .into_iter()
         .map(Into::into)
@@ -89,7 +89,6 @@ mod tests {
         http::{Request, StatusCode},
     };
     use http_body_util::BodyExt; // for `collect`
-    use sea_orm::DatabaseConnection;
 
     use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
     use tower_http::trace::TraceLayer;
@@ -109,9 +108,7 @@ mod tests {
         let mut token_mock = MockTokenProvider::default();
         token_mock
             .expect_list_token_restrictions()
-            .withf(
-                |_: &DatabaseConnection, _: &provider_types::TokenRestrictionListParameters| true,
-            )
+            .withf(|_, _: &provider_types::TokenRestrictionListParameters| true)
             .returning(|_, _| {
                 Ok(vec![provider_types::TokenRestriction {
                     user_id: Some("uid".into()),
@@ -186,15 +183,13 @@ mod tests {
         let mut token_mock = MockTokenProvider::default();
         token_mock
             .expect_list_token_restrictions()
-            .withf(
-                |_: &DatabaseConnection, qp: &provider_types::TokenRestrictionListParameters| {
-                    provider_types::TokenRestrictionListParameters {
-                        domain_id: Some("did".into()),
-                        user_id: Some("uid".into()),
-                        project_id: Some("pid".into()),
-                    } == *qp
-                },
-            )
+            .withf(|_, qp: &provider_types::TokenRestrictionListParameters| {
+                provider_types::TokenRestrictionListParameters {
+                    domain_id: Some("did".into()),
+                    user_id: Some("uid".into()),
+                    project_id: Some("pid".into()),
+                } == *qp
+            })
             .returning(|_, _| {
                 Ok(vec![provider_types::TokenRestriction {
                     user_id: Some("uid".into()),

--- a/src/api/v4/token/restriction/show.rs
+++ b/src/api/v4/token/restriction/show.rs
@@ -59,7 +59,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_token_provider()
-        .get_token_restriction(&state.db, &id, true)
+        .get_token_restriction(&state, &id, true)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {

--- a/src/revoke/backend.rs
+++ b/src/revoke/backend.rs
@@ -15,9 +15,9 @@
 
 use async_trait::async_trait;
 use dyn_clone::DynClone;
-use sea_orm::DatabaseConnection;
 
 use crate::config::Config;
+use crate::keystone::ServiceState;
 use crate::revoke::RevokeProviderError;
 use crate::token::types::Token;
 
@@ -34,7 +34,7 @@ pub trait RevokeBackend: DynClone + Send + Sync + std::fmt::Debug {
     /// Check whether there are existing revocation records that invalidate the token.
     async fn is_token_revoked(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         token: &Token,
     ) -> Result<bool, RevokeProviderError>;
 }

--- a/src/revoke/backend/sql.rs
+++ b/src/revoke/backend/sql.rs
@@ -16,12 +16,12 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
-use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 
 use super::RevokeBackend;
 use crate::config::Config;
 use crate::db::entity::revocation_event as db_revocation_event;
+use crate::keystone::ServiceState;
 use crate::revoke::RevokeProviderError;
 use crate::revoke::backend::error::RevokeDatabaseError;
 use crate::token::types::Token;
@@ -69,11 +69,11 @@ impl RevokeBackend for SqlBackend {
     /// at least one such record.
     async fn is_token_revoked(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         token: &Token,
     ) -> Result<bool, RevokeProviderError> {
         // Check for the token revocation events.
-        if list::count(db, &token.try_into()?).await? > 0 {
+        if list::count(&state.db, &token.try_into()?).await? > 0 {
             Ok(true)
         } else {
             Ok(false)

--- a/src/revoke/mock.rs
+++ b/src/revoke/mock.rs
@@ -16,13 +16,14 @@
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall::mock;
-use sea_orm::DatabaseConnection;
 
 use crate::config::Config;
 use crate::plugin_manager::PluginManager;
 use crate::revoke::RevokeApi;
 use crate::revoke::error::RevokeProviderError;
 use crate::token::types::Token;
+
+use crate::keystone::ServiceState;
 
 #[cfg(test)]
 mock! {
@@ -34,7 +35,7 @@ mock! {
     impl RevokeApi for RevokeProvider {
         async fn is_token_revoked(
             &self,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             token: &Token,
         ) -> Result<bool, RevokeProviderError>;
     }

--- a/src/revoke/mod.rs
+++ b/src/revoke/mod.rs
@@ -37,7 +37,6 @@
 //!
 
 use async_trait::async_trait;
-use sea_orm::DatabaseConnection;
 
 pub mod backend;
 pub mod error;
@@ -46,6 +45,7 @@ mod mock;
 pub(crate) mod types;
 
 use crate::config::Config;
+use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManager;
 use crate::revoke::backend::{RevokeBackend, sql::SqlBackend};
 use crate::revoke::error::RevokeProviderError;
@@ -53,7 +53,6 @@ use crate::token::types::Token;
 
 #[cfg(test)]
 pub use mock::MockRevokeProvider;
-
 pub use types::*;
 
 /// Revoke provider.
@@ -92,12 +91,12 @@ impl RevokeApi for RevokeProvider {
     ///
     /// Checks revocation events matching the token parameters and return `false` if their count is
     /// more than `0`.
-    #[tracing::instrument(level = "info", skip(self, db, token))]
+    #[tracing::instrument(level = "info", skip(self, state, token))]
     async fn is_token_revoked(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         token: &Token,
     ) -> Result<bool, RevokeProviderError> {
-        self.backend_driver.is_token_revoked(db, token).await
+        self.backend_driver.is_token_revoked(state, token).await
     }
 }

--- a/src/revoke/types.rs
+++ b/src/revoke/types.rs
@@ -14,8 +14,8 @@
 //! Token revocation types definitions.
 
 use async_trait::async_trait;
-use sea_orm::DatabaseConnection;
 
+use crate::keystone::ServiceState;
 use crate::revoke::RevokeProviderError;
 use crate::token::types::Token;
 
@@ -28,7 +28,7 @@ pub trait RevokeApi: Send + Sync + Clone {
     /// more than `0`.
     async fn is_token_revoked(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         token: &Token,
     ) -> Result<bool, RevokeProviderError>;
 }

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -26,7 +26,7 @@ pub(crate) fn get_mocked_state_unauthed() -> ServiceState {
     let mut token_mock = MockTokenProvider::default();
     token_mock
         .expect_validate_token()
-        .returning(|_, _, _, _, _| Err(TokenProviderError::InvalidToken));
+        .returning(|_, _, _, _| Err(TokenProviderError::InvalidToken));
 
     let provider = Provider::mocked_builder()
         .token(token_mock)
@@ -46,17 +46,15 @@ pub(crate) fn get_mocked_state_unauthed() -> ServiceState {
 
 pub(crate) fn get_mocked_state(identity_mock: MockIdentityProvider) -> ServiceState {
     let mut token_mock = MockTokenProvider::default();
-    token_mock
-        .expect_validate_token()
-        .returning(|_, _, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+    token_mock.expect_validate_token().returning(|_, _, _, _| {
+        Ok(Token::Unscoped(UnscopedPayload {
+            user_id: "bar".into(),
+            ..Default::default()
+        }))
+    });
     token_mock
         .expect_expand_token_information()
-        .returning(|_, _, _| {
+        .returning(|_, _| {
             Ok(Token::Unscoped(UnscopedPayload {
                 user_id: "bar".into(),
                 ..Default::default()

--- a/src/token/mock.rs
+++ b/src/token/mock.rs
@@ -15,12 +15,11 @@
 
 use async_trait::async_trait;
 use mockall::mock;
-use sea_orm::DatabaseConnection;
 
 use super::error::TokenProviderError;
 use crate::auth::{AuthenticatedInfo, AuthzInfo};
 use crate::config::Config;
-use crate::provider::Provider;
+use crate::keystone::ServiceState;
 
 use super::{
     Token, TokenApi, TokenRestriction, TokenRestrictionCreate, TokenRestrictionListParameters,
@@ -36,8 +35,7 @@ mock! {
     impl TokenApi for TokenProvider {
         async fn authenticate_by_token<'a>(
             &self,
-            provider: &Provider,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             credential: &'a str,
             allow_expired: Option<bool>,
             window_seconds: Option<i64>,
@@ -45,8 +43,7 @@ mock! {
 
         async fn validate_token<'a>(
             &self,
-            provider: &Provider,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             credential: &'a str,
             allow_expired: Option<bool>,
             window_seconds: Option<i64>,
@@ -64,47 +61,45 @@ mock! {
 
         async fn populate_role_assignments(
             &self,
+            state: &ServiceState,
             token: &mut Token,
-            db: &DatabaseConnection,
-            provider: &Provider,
         ) -> Result<(), TokenProviderError>;
 
         async fn expand_token_information(
             &self,
+            state: &ServiceState,
             token: &Token,
-            db: &DatabaseConnection,
-            provider: &Provider,
         ) -> Result<Token, TokenProviderError>;
 
         async fn get_token_restriction<'a>(
             &self,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             id: &'a str,
             expand_roles: bool,
         ) -> Result<Option<TokenRestriction>, TokenProviderError>;
 
         async fn list_token_restrictions<'a>(
             &self,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             params: &TokenRestrictionListParameters,
         ) -> Result<Vec<TokenRestriction>, TokenProviderError>;
 
         async fn create_token_restriction<'a>(
             &self,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             restriction: TokenRestrictionCreate,
         ) -> Result<TokenRestriction, TokenProviderError>;
 
         async fn update_token_restriction<'a>(
             &self,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             id: &'a str,
             restriction: TokenRestrictionUpdate,
         ) -> Result<TokenRestriction, TokenProviderError>;
 
         async fn delete_token_restriction<'a>(
             &self,
-            db: &DatabaseConnection,
+            state: &ServiceState,
             id: &'a str,
         ) -> Result<(), TokenProviderError>;
     }
@@ -112,5 +107,4 @@ mock! {
     impl Clone for TokenProvider {
         fn clone(&self) -> Self;
     }
-
 }

--- a/src/token/types/provider_api.rs
+++ b/src/token/types/provider_api.rs
@@ -14,10 +14,9 @@
 //! Token provider types.
 
 use async_trait::async_trait;
-use sea_orm::DatabaseConnection;
 
 use crate::auth::{AuthenticatedInfo, AuthzInfo};
-use crate::provider::Provider;
+use crate::keystone::ServiceState;
 use crate::token::TokenProviderError;
 
 use super::*;
@@ -25,10 +24,10 @@ use super::*;
 /// Token Provider interface.
 #[async_trait]
 pub trait TokenApi: Send + Sync + Clone {
+    /// Authenticate using the existing token.
     async fn authenticate_by_token<'a>(
         &self,
-        provider: &Provider,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
@@ -37,8 +36,7 @@ pub trait TokenApi: Send + Sync + Clone {
     /// Validate the token
     async fn validate_token<'a>(
         &self,
-        provider: &Provider,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
@@ -58,24 +56,22 @@ pub trait TokenApi: Send + Sync + Clone {
     /// Populate role assignments in the token that support that information
     async fn populate_role_assignments(
         &self,
+        state: &ServiceState,
         token: &mut Token,
-        db: &DatabaseConnection,
-        provider: &Provider,
     ) -> Result<(), TokenProviderError>;
 
     /// Populate additional information (project, domain, roles, etc) in the token that support
     /// that information
     async fn expand_token_information(
         &self,
+        state: &ServiceState,
         token: &Token,
-        db: &DatabaseConnection,
-        provider: &Provider,
     ) -> Result<Token, TokenProviderError>;
 
     /// Get the token restriction by the ID.
     async fn get_token_restriction<'a>(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         id: &'a str,
         expand_roles: bool,
     ) -> Result<Option<TokenRestriction>, TokenProviderError>;
@@ -83,21 +79,21 @@ pub trait TokenApi: Send + Sync + Clone {
     /// Create new token restriction.
     async fn create_token_restriction<'a>(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         restriction: TokenRestrictionCreate,
     ) -> Result<TokenRestriction, TokenProviderError>;
 
     /// List token restrictions.
     async fn list_token_restrictions<'a>(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         params: &TokenRestrictionListParameters,
     ) -> Result<Vec<TokenRestriction>, TokenProviderError>;
 
     /// Update token restriction by the ID.
     async fn update_token_restriction<'a>(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         id: &'a str,
         restriction: TokenRestrictionUpdate,
     ) -> Result<TokenRestriction, TokenProviderError>;
@@ -105,7 +101,7 @@ pub trait TokenApi: Send + Sync + Clone {
     /// Delete token restriction by the ID.
     async fn delete_token_restriction<'a>(
         &self,
-        db: &DatabaseConnection,
+        state: &ServiceState,
         id: &'a str,
     ) -> Result<(), TokenProviderError>;
 }


### PR DESCRIPTION
In order to make providers easier it makes much more sense to pass the
overall app state instead of database connection and provider manager.
This way every backend is able to extract only the information it really
needs and we do not need to extend methods once we figure out that we
need to pass something else.
