### PR TITLE
feat: Add token revocation API

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -17,6 +17,7 @@
     * [Federation IDP](adr/0006-federation-idp.md)
     * [Federation Mapping](adr/0007-federation-mapping.md)
     * [Workload Federation](adr/0008-workload-federation.md)
+    * [Auth token revocation](adr/0009-auth-token-revoke.md)
 * [Policy enforcement](./policy.md)
 * [Fernet token]()
   * [Token payloads]()

--- a/doc/src/adr/0009-auth-token-revoke.md
+++ b/doc/src/adr/0009-auth-token-revoke.md
@@ -1,0 +1,119 @@
+# 9. Auth token revocation
+
+Date: 2025-11-18
+
+## Status
+
+Accepted
+
+## Context
+
+Issued tokens are having certain configurable validity. In cases when a user
+need to be disabled, the project deactivated, or simply to prevent the token use
+after the work has been completed it is necessary to provide the possibility to
+invalidate the tokens. Python Keystone provides this possibility and so it is
+necessary to implement it in the same way.
+
+Since original functionality is not explicitly documented this ADR will become
+the base of such information.
+
+## Decision
+
+Fernet token revocation is implemented based on the `revocation_event` database
+table.
+
+The table has following fields:
+
+```
+    pub id: i32,
+    pub domain_id: Option<String>,
+    pub project_id: Option<String>,
+    pub user_id: Option<String>,
+    pub role_id: Option<String>,
+    pub trust_id: Option<String>,
+    pub consumer_id: Option<String>,
+    pub access_token_id: Option<String>,
+    pub issued_before: DateTime,
+    pub expires_at: Option<DateTime>,
+    pub revoked_at: DateTime,
+    pub audit_id: Option<String>,
+    pub audit_chain_id: Option<String>,
+```
+
+### Token revocation
+
+When a revocation of thecurrently valid token is being requested the record with
+the following information is being inserted into the database:
+
+- `audit_id` is populated with the first entry of the token `audit_ids` list.
+  When this list is empty an error is being returned.
+- `issued_before` is set to the current time with the UTC timezone.
+- `revoked_at` is set to the current time with the UTC timezone.
+- other fields are left empty.
+
+### Revocation check
+
+A token validation for being revoked is performed based on the presence of the
+revocation events in the `revocation_event` table matching the expanded token
+properties. This means that before the token revocation is being checked
+additional database queries for expanding the scope information including the
+roles the token is granting are performed.
+
+Following conditions are combined with the AND condition:
+
+- First element of the token's `audit_ids` property is compared against the
+  database record. When this list is empty an error is being returned.
+- `token.project_id` is compared against the database record when present.
+- `token.user_id` is compared against the database record when present.
+- `token.trustor_id` is compared against the database record `user_id` when present.
+- `token.trustee_id` is compared against the database record `user_id` when present.
+- `token.trust_id` is compared against the database record `trust_id` when present.
+- `token.issued_at` is compared against the database record with
+  `revocation_event.issued_before >= token.issued_at`.
+
+Python version of the Keystone applies additional match verification for the
+selected data on the server side and not in the database query.
+
+- When `revocation_event.domain_id` is set it is compared against
+`token.domain_id` and `token.identity_domain_id`.
+- When `revocation_event.role_id` is present it is compared against every of the
+`token.roles`.
+
+After the first non matching result further evaluation is being stopped.
+Logically there does not seem to be a reason for such handling and it looks to
+be an evolutionary design decision. Following checks can be added into the
+single database query with a different logic only comparing the corresponding
+fields when the column is not empty.
+
+While following checks allow much higher details of the revocation events in the
+context of the usual fernet token revocation it is only going to match on the
+`audit_id` and `issued_before`.
+
+
+### Revocation table purge
+
+In the python Keystone there is no automatic cleanup handling. Due to that
+expired records are removed during the revocation check. Records to be expired
+are selected using the following logic.
+
+- `expire_delta = CONF.token.expiration + CONF.token.expiration_buffer`
+- `oldest = utc.now() - expire_delta`
+- `DELETE from revocation_event WHERE revoked_at < oldest`
+
+When both python and rust Keystone versions are deployed in parallel and both
+try to delete expired records errors can occur. However, if only rust version is
+validating the tokens python version will not perform any backups. Additionally
+no errors were reported yet in installations with multiple Keystone instances.
+Therefore it is necessary for the rust implementation to do periodic cleanup. It
+should be exexcuted with the following query filter: `revoked_at < (now -
+(expiration + expiration_buffer))`. Such implementation must be made optional
+with possibility to disable this behavior using the config file.
+
+## Consequences
+
+- Database table with the revocation events must be periodically cleaned up.
+
+- Token validation processing time is increased with the database lookup.
+
+- Expired revocation records are optionally periodically cleaned by the rust
+implementation.

--- a/policy/auth/token/revoke.rego
+++ b/policy/auth/token/revoke.rego
@@ -1,0 +1,26 @@
+package identity.auth.token.revoke
+
+import data.identity
+
+# Revoke the token
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+# allow if {
+# 	"service" in input.credentials.roles
+# }
+
+# allow if {
+# 	"reader" in input.credentials.roles
+# 	input.credentials.system_scope != null
+# 	"all" == input.credentials.system_scope
+# }
+
+allow if {
+	identity.token_subject
+}
+

--- a/policy/auth/token/revoke_test.rego
+++ b/policy/auth/token/revoke_test.rego
@@ -1,0 +1,15 @@
+package test_auth_token_revoke
+
+import data.identity.auth.token.revoke
+
+test_allowed if {
+	revoke.allow with input as {"credentials": {"roles": ["admin"]}}
+	revoke.allow with input as {"credentials": {"user_id": "foo"}, "target": {"token": {"user_id": "foo"}}}
+}
+
+test_forbidden if {
+	not revoke.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "not_all"}}
+	not revoke.allow with input as {"credentials": {"roles": ["manager"], "user_id": "foo"}, "target": {"token": {"user_id": "bar"}}}
+	not revoke.allow with input as {"credentials": {"roles": ["member"], "user_id": "foo"}, "target": {"token": {"user_id": "bar"}}}
+	not revoke.allow with input as {"credentials": {"roles": ["reader"], "user_id": "foo"}, "target": {"token": {"user_id": "bar"}}}
+}

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -43,7 +43,7 @@ where
             auth_header
         } else {
             debug!("No supported information has been provided.");
-            return Err(KeystoneApiError::Unauthorized)?;
+            return Err(KeystoneApiError::Unauthorized(None))?;
         };
 
         let state = Arc::from_ref(state);
@@ -51,17 +51,10 @@ where
         let token = state
             .provider
             .get_token_provider()
-            .validate_token(&state, auth_header, Some(false), None)
+            .validate_token(&state, auth_header, Some(false), None, Some(true))
             .await
             .inspect_err(|e| error!("{:#?}", e))
-            .map_err(|_| KeystoneApiError::Unauthorized)?;
-
-        // Expand the information (user, project, roles, etc) about the user when a token is valid
-        let token = state
-            .provider
-            .get_token_provider()
-            .expand_token_information(&state, &token)
-            .await?;
+            .map_err(|_| KeystoneApiError::Unauthorized(None))?;
 
         Ok(Self(token))
     }

--- a/src/api/v3/auth/token/common.rs
+++ b/src/api/v3/auth/token/common.rs
@@ -93,7 +93,7 @@ pub(super) async fn authenticate_request(
         }
     }
     authenticated_info
-        .ok_or(KeystoneApiError::Unauthorized)
+        .ok_or(KeystoneApiError::Unauthorized(None))
         .and_then(|authn| {
             authn.validate()?;
             Ok(authn)
@@ -120,14 +120,14 @@ pub(super) async fn get_authz_info(
             if let Some(project) = find_project_from_scope(state, scope).await? {
                 AuthzInfo::Project(project)
             } else {
-                return Err(KeystoneApiError::Unauthorized);
+                return Err(KeystoneApiError::Unauthorized(None));
             }
         }
         Some(Scope::Domain(scope)) => {
             if let Ok(domain) = get_domain(state, scope.id.as_ref(), scope.name.as_ref()).await {
                 AuthzInfo::Domain(domain)
             } else {
-                return Err(KeystoneApiError::Unauthorized);
+                return Err(KeystoneApiError::Unauthorized(None));
             }
         }
         Some(Scope::System(_scope)) => {
@@ -337,7 +337,7 @@ mod tests {
             },
         )
         .await;
-        if let KeystoneApiError::Unauthorized = rsp.unwrap_err() {
+        if let KeystoneApiError::Unauthorized(..) = rsp.unwrap_err() {
         } else {
             panic!("Should receive Unauthorized");
         }

--- a/src/api/v3/auth/token/delete.rs
+++ b/src/api/v3/auth/token/delete.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Revoke the authentication token.
+//!
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+use mockall_double::double;
+use serde_json::{json, to_value};
+use tracing::error;
+
+use crate::api::{auth::Auth, error::KeystoneApiError};
+use crate::keystone::ServiceState;
+#[double]
+use crate::policy::Policy;
+use crate::revoke::RevokeApi;
+use crate::token::TokenApi;
+
+/// Revoke token.
+///
+/// Revokes a token.
+///
+/// This call is similar to the HEAD /auth/tokens call except that the `X-Subject-Token` token is
+/// immediately not valid, regardless of the expires_at attribute value. An additional
+/// `X-Auth-Token` is not required.
+#[utoipa::path(
+    delete,
+    path = "/",
+    responses(
+        (status = 204, description = "Token has been revoked."),
+    ),
+    tag="auth"
+)]
+#[tracing::instrument(
+    name = "api::v3::token::delete",
+    level = "debug",
+    skip(state, headers, user_auth, policy)
+)]
+pub(super) async fn delete(
+    Auth(user_auth): Auth,
+    mut policy: Policy,
+    headers: HeaderMap,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let subject_token: String = headers
+        .get("X-Subject-Token")
+        .ok_or(KeystoneApiError::SubjectTokenMissing)?
+        .to_str()
+        .map_err(|_| KeystoneApiError::InvalidHeader)?
+        .to_string();
+
+    // Default behavior is to return 404 for expired tokens. It makes sense to log internally the
+    // error before mapping it.
+    let token = state
+        .provider
+        .get_token_provider()
+        .validate_token(&state, &subject_token, None, None, None)
+        .await
+        .inspect_err(|e| error!("{:?}", e.to_string()))
+        .map_err(|_| KeystoneApiError::NotFound {
+            resource: "token".into(),
+            identifier: String::new(),
+        })?;
+
+    policy
+        .enforce(
+            "identity/auth/token/revoke",
+            &user_auth,
+            to_value(json!({"token": &token}))?,
+            None,
+        )
+        .await?;
+
+    state
+        .provider
+        .get_revoke_provider()
+        .revoke_token(&state, &token)
+        .await
+        .map_err(|_| KeystoneApiError::Forbidden)?;
+
+    Ok((StatusCode::NO_CONTENT).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use sea_orm::DatabaseConnection;
+    use std::sync::Arc;
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use crate::config::Config;
+    use crate::keystone::Service;
+    use crate::provider::Provider;
+    use crate::revoke::MockRevokeProvider;
+    use crate::token::{
+        MockTokenProvider, Token as ProviderToken, TokenProviderError, UnscopedPayload,
+    };
+
+    use super::super::{openapi_router, tests::get_policy_factory_mock};
+
+    fn get_prepopulated_token_mock() -> MockTokenProvider {
+        let decoded_auth_token = ProviderToken::Unscoped(UnscopedPayload {
+            user_id: "bar".into(),
+            ..Default::default()
+        });
+
+        let mut token_mock = MockTokenProvider::default();
+        // x-auth-token validated
+        let decoded_auth_token_clone1 = decoded_auth_token.clone();
+        token_mock
+            .expect_validate_token()
+            .withf(|_, token: &'_ str, _, _, _| token == "foo")
+            .returning(move |_, _, _, _, _| Ok(decoded_auth_token_clone1.clone()));
+        // auth-token expanded
+        let decoded_auth_token_clone2 = decoded_auth_token.clone();
+        token_mock
+            .expect_expand_token_information()
+            .withf(move |_, token: &ProviderToken| *token == decoded_auth_token_clone2.clone())
+            .returning(|_, _| {
+                Ok(ProviderToken::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
+        // auth-token roles populated
+        let decoded_auth_token_clone3 = decoded_auth_token.clone();
+        token_mock
+            .expect_populate_role_assignments()
+            .withf(move |_, token: &ProviderToken| *token == decoded_auth_token_clone3.clone())
+            .returning(|_, _| Ok(()));
+
+        token_mock
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let decoded_subject_token = ProviderToken::Unscoped(UnscopedPayload {
+            user_id: "foobar".into(),
+            ..Default::default()
+        });
+        let mut token_mock = get_prepopulated_token_mock();
+
+        // subject token validated
+        let decoded_subject_token_clone = decoded_subject_token.clone();
+        token_mock
+            .expect_validate_token()
+            .withf(|_, token: &'_ str, _, _, _| token == "baz")
+            .returning(move |_, _, _, _, _| Ok(decoded_subject_token_clone.clone()));
+
+        let mut revoke_mock = MockRevokeProvider::default();
+        // subject token revoked
+        let decoded_subject_token_clone2 = decoded_subject_token.clone();
+        revoke_mock
+            .expect_revoke_token()
+            .withf(move |_, token: &ProviderToken| *token == decoded_subject_token_clone2.clone())
+            .returning(|_, _| Ok(()));
+
+        let provider = Provider::mocked_builder()
+            .token(token_mock)
+            .revoke(revoke_mock)
+            .build()
+            .unwrap();
+
+        let state = Arc::new(
+            Service::new(
+                Config::default(),
+                DatabaseConnection::Disconnected,
+                provider,
+                get_policy_factory_mock(),
+            )
+            .unwrap(),
+        );
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .method("DELETE")
+                    .header("x-auth-token", "foo")
+                    .header("x-subject-token", "baz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired() {
+        let mut token_mock = get_prepopulated_token_mock();
+        // subject token validated
+        token_mock
+            .expect_validate_token()
+            .withf(|_, token: &'_ str, _, _, _| token == "baz")
+            .returning(move |_, _, _, _, _| Err(TokenProviderError::Expired));
+
+        let provider = Provider::mocked_builder()
+            .token(token_mock)
+            .build()
+            .unwrap();
+
+        let state = Arc::new(
+            Service::new(
+                Config::default(),
+                DatabaseConnection::Disconnected,
+                provider,
+                get_policy_factory_mock(),
+            )
+            .unwrap(),
+        );
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .method("DELETE")
+                    .header("x-auth-token", "foo")
+                    .header("x-subject-token", "baz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_delete_revoked() {
+        let mut token_mock = get_prepopulated_token_mock();
+        // subject token validated
+        token_mock
+            .expect_validate_token()
+            .withf(|_, token: &'_ str, _, _, _| token == "baz")
+            .returning(move |_, _, _, _, _| Err(TokenProviderError::TokenRevoked));
+
+        let provider = Provider::mocked_builder()
+            .token(token_mock)
+            .build()
+            .unwrap();
+
+        let state = Arc::new(
+            Service::new(
+                Config::default(),
+                DatabaseConnection::Disconnected,
+                provider,
+                get_policy_factory_mock(),
+            )
+            .unwrap(),
+        );
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .method("DELETE")
+                    .header("x-auth-token", "foo")
+                    .header("x-subject-token", "baz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/src/api/v3/auth/token/mod.rs
+++ b/src/api/v3/auth/token/mod.rs
@@ -20,12 +20,13 @@ use crate::keystone::ServiceState;
 
 mod common;
 mod create;
+mod delete;
 mod show;
 mod token_impl;
 pub mod types;
 
 pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
-    OpenApiRouter::new().routes(routes!(show::show, create::create))
+    OpenApiRouter::new().routes(routes!(show::show, create::create, delete::delete))
 }
 
 #[cfg(test)]

--- a/src/api/v3/role/mod.rs
+++ b/src/api/v3/role/mod.rs
@@ -129,12 +129,14 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+        token_mock
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
+                Ok(Token::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
         token_mock
             .expect_expand_token_information()
             .returning(|_, _| {

--- a/src/api/v3/role_assignment/mod.rs
+++ b/src/api/v3/role_assignment/mod.rs
@@ -99,12 +99,14 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+        token_mock
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
+                Ok(Token::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
         token_mock
             .expect_expand_token_information()
             .returning(|_, _| {

--- a/src/api/v4/federation/common.rs
+++ b/src/api/v4/federation/common.rs
@@ -46,14 +46,14 @@ pub(super) async fn get_authz_info(
             if let Some(project) = find_project_from_scope(state, &scope.into()).await? {
                 AuthzInfo::Project(project)
             } else {
-                return Err(KeystoneApiError::Unauthorized);
+                return Err(KeystoneApiError::Unauthorized(None));
             }
         }
         Some(ProviderScope::Domain(scope)) => {
             if let Ok(domain) = get_domain(state, scope.id.as_ref(), scope.name.as_ref()).await {
                 AuthzInfo::Domain(domain)
             } else {
-                return Err(KeystoneApiError::Unauthorized);
+                return Err(KeystoneApiError::Unauthorized(None));
             }
         }
         Some(ProviderScope::System(_scope)) => todo!(),

--- a/src/api/v4/federation/error.rs
+++ b/src/api/v4/federation/error.rs
@@ -214,11 +214,11 @@ impl From<OidcError> for KeystoneApiError {
             }
             OidcError::NonJwtMapping | OidcError::NoJwtIssuer => {
                 // Not exposing info about mapping and idp existence.
-                KeystoneApiError::Unauthorized
+                KeystoneApiError::Unauthorized(Some("mapping error".to_string()))
             }
             OidcError::UserNotFound(_) => {
                 // Not exposing info about mapping and idp existence.
-                KeystoneApiError::Unauthorized
+                KeystoneApiError::Unauthorized(Some("User not found".to_string()))
             }
         }
     }

--- a/src/api/v4/federation/identity_provider.rs
+++ b/src/api/v4/federation/identity_provider.rs
@@ -43,11 +43,8 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
 
 #[cfg(test)]
 mod tests {
-
-    // for `collect`
     use sea_orm::DatabaseConnection;
     use std::sync::Arc;
-    // for `call`, `oneshot`, and `ready`
 
     use crate::config::Config;
     use crate::federation::MockFederationProvider;
@@ -63,15 +60,9 @@ mod tests {
         policy_allowed_see_other_domains: Option<bool>,
     ) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
         token_mock
-            .expect_expand_token_information()
-            .returning(|_, _| {
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
                 Ok(Token::Unscoped(UnscopedPayload {
                     user_id: "bar".into(),
                     user: Some(UserResponse {

--- a/src/api/v4/federation/mapping.rs
+++ b/src/api/v4/federation/mapping.rs
@@ -56,12 +56,14 @@ mod tests {
         policy_allowed: bool,
     ) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+        token_mock
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
+                Ok(Token::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
         token_mock
             .expect_expand_token_information()
             .returning(|_, _| {

--- a/src/api/v4/role/mod.rs
+++ b/src/api/v4/role/mod.rs
@@ -58,12 +58,14 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+        token_mock
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
+                Ok(Token::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
         token_mock
             .expect_expand_token_information()
             .returning(|_, _| {

--- a/src/api/v4/role_assignment/mod.rs
+++ b/src/api/v4/role_assignment/mod.rs
@@ -54,12 +54,14 @@ mod tests {
 
     fn get_mocked_state(assignment_mock: MockAssignmentProvider) -> ServiceState {
         let mut token_mock = MockTokenProvider::default();
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+        token_mock
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
+                Ok(Token::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
         token_mock
             .expect_expand_token_information()
             .returning(|_, _| {

--- a/src/api/v4/token/restriction.rs
+++ b/src/api/v4/token/restriction.rs
@@ -63,12 +63,14 @@ mod tests {
         policy_allowed: bool,
         policy_allowed_see_other_domains: Option<bool>,
     ) -> ServiceState {
-        token_mock.expect_validate_token().returning(|_, _, _, _| {
-            Ok(Token::Unscoped(UnscopedPayload {
-                user_id: "bar".into(),
-                ..Default::default()
-            }))
-        });
+        token_mock
+            .expect_validate_token()
+            .returning(|_, _, _, _, _| {
+                Ok(Token::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
+            });
         token_mock
             .expect_expand_token_information()
             .returning(|_, _| {

--- a/src/revoke/mod.rs
+++ b/src/revoke/mod.rs
@@ -97,6 +97,7 @@ impl RevokeApi for RevokeProvider {
         state: &ServiceState,
         token: &Token,
     ) -> Result<bool, RevokeProviderError> {
+        tracing::info!("Checking for the revocation events");
         self.backend_driver.is_token_revoked(state, token).await
     }
 

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -26,7 +26,7 @@ pub(crate) fn get_mocked_state_unauthed() -> ServiceState {
     let mut token_mock = MockTokenProvider::default();
     token_mock
         .expect_validate_token()
-        .returning(|_, _, _, _| Err(TokenProviderError::InvalidToken));
+        .returning(|_, _, _, _, _| Err(TokenProviderError::InvalidToken));
 
     let provider = Provider::mocked_builder()
         .token(token_mock)
@@ -46,12 +46,14 @@ pub(crate) fn get_mocked_state_unauthed() -> ServiceState {
 
 pub(crate) fn get_mocked_state(identity_mock: MockIdentityProvider) -> ServiceState {
     let mut token_mock = MockTokenProvider::default();
-    token_mock.expect_validate_token().returning(|_, _, _, _| {
-        Ok(Token::Unscoped(UnscopedPayload {
-            user_id: "bar".into(),
-            ..Default::default()
-        }))
-    });
+    token_mock
+        .expect_validate_token()
+        .returning(|_, _, _, _, _| {
+            Ok(Token::Unscoped(UnscopedPayload {
+                user_id: "bar".into(),
+                ..Default::default()
+            }))
+        });
     token_mock
         .expect_expand_token_information()
         .returning(|_, _| {

--- a/src/token/mock.rs
+++ b/src/token/mock.rs
@@ -47,6 +47,7 @@ mock! {
             credential: &'a str,
             allow_expired: Option<bool>,
             window_seconds: Option<i64>,
+            expand: Option<bool>
         ) -> Result<Token, TokenProviderError>;
 
         #[mockall::concretize]

--- a/src/token/types/provider_api.rs
+++ b/src/token/types/provider_api.rs
@@ -33,16 +33,33 @@ pub trait TokenApi: Send + Sync + Clone {
         window_seconds: Option<i64>,
     ) -> Result<AuthenticatedInfo, TokenProviderError>;
 
-    /// Validate the token
+    /// Validate the token.
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - An application state.
+    /// * `credential` - A token as a string.
+    /// * `allow_expired` - Indicates whether for the expired token the an error should be raised
+    /// or not.
+    /// * `window_seconds` - An additional token expiration buffer that is added to the
+    /// `token.expires_at() during the expiration calculation.
+    /// * `expand` - Indicates whether the token information should be expanded or not. Defaults to
+    /// true.
     async fn validate_token<'a>(
         &self,
         state: &ServiceState,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
+        expand: Option<bool>,
     ) -> Result<Token, TokenProviderError>;
 
-    /// Issue a token for given parameters
+    /// Issue a token for given parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `authentication_info` - Authentication information for the token.
+    /// * `authz_info` - Authorization information (scope) for the token.
     fn issue_token(
         &self,
         authentication_info: AuthenticatedInfo,

--- a/tests/functional/auth/token.rs
+++ b/tests/functional/auth/token.rs
@@ -12,4 +12,5 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+mod revoke;
 mod validate;

--- a/tests/functional/auth/token/revoke.rs
+++ b/tests/functional/auth/token/revoke.rs
@@ -1,0 +1,215 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use reqwest::{Client, StatusCode};
+use std::env;
+use tracing_test::traced_test;
+
+use openstack_keystone::api::types::*;
+use openstack_keystone::api::v3::auth::token::types::*;
+
+use crate::common::*;
+
+#[tokio::test]
+#[traced_test]
+async fn test_revoke() {
+    let keystone_url = env::var("KEYSTONE_URL").expect("KEYSTONE_URL is set");
+    let client = Client::new();
+
+    let admin_token = auth(
+        &keystone_url,
+        get_password_auth(
+            "admin",
+            env::var("OPENSTACK_ADMIN_PASSWORD").unwrap_or("password".to_string()),
+            "default",
+        )
+        .expect("can't prepare password auth"),
+        Some(Scope::Project(
+            ProjectScopeBuilder::default()
+                .name("admin")
+                .domain(DomainBuilder::default().id("default").build().unwrap())
+                .build()
+                .unwrap(),
+        )),
+    )
+    .await
+    .expect("no token");
+
+    let test_token = auth(
+        &keystone_url,
+        get_password_auth(
+            "admin",
+            env::var("OPENSTACK_ADMIN_PASSWORD").unwrap_or("password".to_string()),
+            "default",
+        )
+        .expect("can't prepare password auth"),
+        Some(Scope::Project(
+            ProjectScopeBuilder::default()
+                .name("admin")
+                .domain(DomainBuilder::default().id("default").build().unwrap())
+                .build()
+                .unwrap(),
+        )),
+    )
+    .await
+    .expect("no token");
+
+    let _auth_rsp: TokenResponse = check_token(
+        &client,
+        keystone_url.clone(),
+        admin_token.clone(),
+        test_token.clone(),
+    )
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    let rsp = client
+        .delete(format!("{}/v3/auth/tokens", keystone_url))
+        .header("x-auth-token", admin_token.clone())
+        .header("x-subject-token", test_token.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(rsp.status(), StatusCode::NO_CONTENT);
+
+    let rsp = client
+        .get(format!("{}/v3/auth/tokens", keystone_url))
+        .header("x-auth-token", admin_token.clone())
+        .header("x-subject-token", test_token.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(rsp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_revoke_parent_invalidates_child() {
+    let keystone_url = env::var("KEYSTONE_URL").expect("KEYSTONE_URL is set");
+    let client = Client::new();
+
+    let admin_token = auth(
+        &keystone_url,
+        get_password_auth(
+            "admin",
+            env::var("OPENSTACK_ADMIN_PASSWORD").unwrap_or("password".to_string()),
+            "default",
+        )
+        .expect("can't prepare password auth"),
+        Some(Scope::Project(
+            ProjectScopeBuilder::default()
+                .name("admin")
+                .domain(DomainBuilder::default().id("default").build().unwrap())
+                .build()
+                .unwrap(),
+        )),
+    )
+    .await
+    .expect("no token");
+
+    let parent_token = auth(
+        &keystone_url,
+        get_password_auth(
+            "admin",
+            env::var("OPENSTACK_ADMIN_PASSWORD").unwrap_or("password".to_string()),
+            "default",
+        )
+        .expect("can't prepare password auth"),
+        Some(Scope::Project(
+            ProjectScopeBuilder::default()
+                .name("admin")
+                .domain(DomainBuilder::default().id("default").build().unwrap())
+                .build()
+                .unwrap(),
+        )),
+    )
+    .await
+    .expect("no token");
+
+    let child_token = auth_with_token(
+        &keystone_url,
+        &parent_token,
+        Some(Scope::Project(
+            ProjectScopeBuilder::default()
+                .name("admin")
+                .domain(DomainBuilder::default().id("default").build().unwrap())
+                .build()
+                .unwrap(),
+        )),
+    )
+    .await
+    .expect("no token");
+
+    let _auth_rsp: TokenResponse = check_token(
+        &client,
+        keystone_url.clone(),
+        admin_token.clone(),
+        parent_token.clone(),
+    )
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    let _auth_rsp: TokenResponse = check_token(
+        &client,
+        keystone_url.clone(),
+        admin_token.clone(),
+        child_token.clone(),
+    )
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    let rsp = client
+        .delete(format!("{}/v3/auth/tokens", keystone_url))
+        .header("x-auth-token", admin_token.clone())
+        .header("x-subject-token", parent_token.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(rsp.status(), StatusCode::NO_CONTENT);
+
+    assert_eq!(
+        StatusCode::NOT_FOUND,
+        check_token(
+            &client,
+            keystone_url.clone(),
+            admin_token.clone(),
+            parent_token.clone(),
+        )
+        .await
+        .unwrap()
+        .status()
+    );
+
+    assert_eq!(
+        StatusCode::NOT_FOUND,
+        check_token(
+            &client,
+            keystone_url.clone(),
+            admin_token.clone(),
+            child_token.clone(),
+        )
+        .await
+        .unwrap()
+        .status()
+    );
+}


### PR DESCRIPTION
- Add token delete (revoke) api
- Document reverse-engineered design under ADR
- Add functional test to ensure revoked token is not accepted.
- Ensure that `validate_token` expands the token by default, since this
  is expected by the revocation check.
