### PR TITLE
chore(ci): Install mdbook and memrmaid plugin from releases

### DIFF
--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -33,8 +33,8 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-      MDBOOK_VERSION: 0.4.51
+    # env:
+    #   MDBOOK_VERSION: 0.4.51
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -43,12 +43,26 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Install mdBook
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
-          cargo install mdbook-mermaid
+      - name: Install Mdbood
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
+        with:
+          repo: rust-land/mdbook
+          tag: v0.5.1
+          cache: enable
+
+      - name: Install Mdbood
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
+        with:
+          repo: badboy/mdbook-mermaid
+          tag: v0.17.0
+          cache: enable
+
+      #- name: Install mdBook
+      #  run: |
+      #    curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+      #    rustup update
+      #    cargo install --version ${MDBOOK_VERSION} mdbook
+      #    cargo install mdbook-mermaid
 
       - name: Generate OpenAPI
         run: cargo run --bin keystone -- --dump-openapi yaml > doc/src/openapi.yaml


### PR DESCRIPTION
mdbook-mermaid plugin again started crashing due do the incompatible
versions. Switch to installing them both with concrete versions from
github releases directly.
