### PR TITLE
chore: Remove repeated checkout action step

### DIFF
--- a/.github/actions/deploy_keystone/action.yml
+++ b/.github/actions/deploy_keystone/action.yml
@@ -5,8 +5,6 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
     - name: Enable cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:


### PR DESCRIPTION
GitHub checkout action update started to fail on the duplicated
authorization header caused by auth reuse, perhaps the repeated
invocation.
