### PR TITLE
fix: Fix logic for application credential token roles

### DIFF
--- a/src/application_credential/types/application_credential.rs
+++ b/src/application_credential/types/application_credential.rs
@@ -42,17 +42,17 @@ pub struct ApplicationCredential {
     pub expires_at: Option<DateTime<Utc>>,
 
     /// The ID of the application credential.
-    #[validate(length(max = 64))]
+    #[validate(length(min = 1, max = 64))]
     pub id: String,
 
     /// The name of the application credential.
-    #[validate(length(max = 255))]
+    #[validate(length(min = 1, max = 255))]
     pub name: String,
 
     /// The ID of the project the application credential was created for and
     /// that authentication requests using this application credential will
     /// be scoped to.
-    #[validate(length(max = 64))]
+    #[validate(length(min = 1, max = 64))]
     pub project_id: String,
 
     /// A list of one or more roles that this application credential has
@@ -66,7 +66,7 @@ pub struct ApplicationCredential {
     pub unrestricted: bool,
 
     /// The ID of the user who owns the application credential.
-    #[validate(length(max = 64))]
+    #[validate(length(min = 1, max = 64))]
     pub user_id: String,
 }
 

--- a/src/token/error.rs
+++ b/src/token/error.rs
@@ -21,6 +21,26 @@ use thiserror::Error;
 /// Token provider error.
 #[derive(Error, Debug)]
 pub enum TokenProviderError {
+    /// Application Credential used in the token is not found.
+    #[error("application credential with id: {0} not found")]
+    ApplicationCredentialNotFound(String),
+
+    /// Application Credential has expired.
+    #[error("application credential has expired")]
+    ApplicationCredentialExpired,
+
+    /// Application credential provider error.
+    #[error(transparent)]
+    ApplicationCredentialProvider {
+        /// The source of the error.
+        #[from]
+        source: crate::application_credential::error::ApplicationCredentialProviderError,
+    },
+
+    /// Application Credential is bound to the other project.
+    #[error("application credential is bound to another project")]
+    ApplicationCredentialScopeMismatch,
+
     /// IO error.
     #[error("io error: {}", source)]
     Io {

--- a/src/token/types.rs
+++ b/src/token/types.rs
@@ -50,48 +50,48 @@ pub use unscoped::*;
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum Token {
-    /// Unscoped.
-    Unscoped(UnscopedPayload),
+    /// Application credential.
+    ApplicationCredential(ApplicationCredentialPayload),
     /// Domain scoped.
     DomainScope(DomainScopePayload),
-    /// Project scoped.
-    ProjectScope(ProjectScopePayload),
     /// Federated unscoped.
     FederationUnscoped(FederationUnscopedPayload),
     /// Federated project scoped.
     FederationProjectScope(FederationProjectScopePayload),
     /// Federated domain scoped.
     FederationDomainScope(FederationDomainScopePayload),
-    /// Application credential.
-    ApplicationCredential(ApplicationCredentialPayload),
+    /// Project scoped.
+    ProjectScope(ProjectScopePayload),
     /// Restricted.
     Restricted(RestrictedPayload),
+    /// Unscoped.
+    Unscoped(UnscopedPayload),
 }
 
 impl Token {
     pub const fn user_id(&self) -> &String {
         match self {
-            Self::Unscoped(x) => &x.user_id,
-            Self::ProjectScope(x) => &x.user_id,
+            Self::ApplicationCredential(x) => &x.user_id,
             Self::DomainScope(x) => &x.user_id,
             Self::FederationUnscoped(x) => &x.user_id,
             Self::FederationProjectScope(x) => &x.user_id,
             Self::FederationDomainScope(x) => &x.user_id,
-            Self::ApplicationCredential(x) => &x.user_id,
+            Self::ProjectScope(x) => &x.user_id,
             Self::Restricted(x) => &x.user_id,
+            Self::Unscoped(x) => &x.user_id,
         }
     }
 
     pub const fn user(&self) -> &Option<UserResponse> {
         match self {
-            Self::Unscoped(x) => &x.user,
-            Self::ProjectScope(x) => &x.user,
+            Self::ApplicationCredential(x) => &x.user,
             Self::DomainScope(x) => &x.user,
             Self::FederationUnscoped(x) => &x.user,
             Self::FederationProjectScope(x) => &x.user,
             Self::FederationDomainScope(x) => &x.user,
-            Self::ApplicationCredential(x) => &x.user,
+            Self::ProjectScope(x) => &x.user,
             Self::Restricted(x) => &x.user,
+            Self::Unscoped(x) => &x.user,
         }
     }
 
@@ -101,14 +101,14 @@ impl Token {
     /// `issued_at` into the token payload.
     pub(super) fn set_issued_at(&mut self, issued_at: DateTime<Utc>) -> &mut Self {
         match self {
-            Self::Unscoped(x) => x.issued_at = issued_at,
-            Self::ProjectScope(x) => x.issued_at = issued_at,
+            Self::ApplicationCredential(x) => x.issued_at = issued_at,
             Self::DomainScope(x) => x.issued_at = issued_at,
             Self::FederationUnscoped(x) => x.issued_at = issued_at,
             Self::FederationProjectScope(x) => x.issued_at = issued_at,
             Self::FederationDomainScope(x) => x.issued_at = issued_at,
-            Self::ApplicationCredential(x) => x.issued_at = issued_at,
+            Self::ProjectScope(x) => x.issued_at = issued_at,
             Self::Restricted(x) => x.issued_at = issued_at,
+            Self::Unscoped(x) => x.issued_at = issued_at,
         }
         self
     }
@@ -119,59 +119,60 @@ impl Token {
     /// payload and not the token payload).
     pub const fn issued_at(&self) -> &DateTime<Utc> {
         match self {
-            Self::Unscoped(x) => &x.issued_at,
-            Self::ProjectScope(x) => &x.issued_at,
+            Self::ApplicationCredential(x) => &x.issued_at,
             Self::DomainScope(x) => &x.issued_at,
             Self::FederationUnscoped(x) => &x.issued_at,
             Self::FederationProjectScope(x) => &x.issued_at,
             Self::FederationDomainScope(x) => &x.issued_at,
-            Self::ApplicationCredential(x) => &x.issued_at,
+            Self::ProjectScope(x) => &x.issued_at,
             Self::Restricted(x) => &x.issued_at,
+            Self::Unscoped(x) => &x.issued_at,
         }
     }
 
     /// Get token expiration timestamp.
     pub const fn expires_at(&self) -> &DateTime<Utc> {
         match self {
-            Self::Unscoped(x) => &x.expires_at,
-            Self::ProjectScope(x) => &x.expires_at,
+            Self::ApplicationCredential(x) => &x.expires_at,
             Self::DomainScope(x) => &x.expires_at,
             Self::FederationUnscoped(x) => &x.expires_at,
             Self::FederationProjectScope(x) => &x.expires_at,
             Self::FederationDomainScope(x) => &x.expires_at,
-            Self::ApplicationCredential(x) => &x.expires_at,
+            Self::ProjectScope(x) => &x.expires_at,
             Self::Restricted(x) => &x.expires_at,
+            Self::Unscoped(x) => &x.expires_at,
         }
     }
 
     pub const fn methods(&self) -> &Vec<String> {
         match self {
-            Self::Unscoped(x) => &x.methods,
-            Self::ProjectScope(x) => &x.methods,
+            Self::ApplicationCredential(x) => &x.methods,
             Self::DomainScope(x) => &x.methods,
             Self::FederationUnscoped(x) => &x.methods,
             Self::FederationProjectScope(x) => &x.methods,
             Self::FederationDomainScope(x) => &x.methods,
-            Self::ApplicationCredential(x) => &x.methods,
+            Self::ProjectScope(x) => &x.methods,
             Self::Restricted(x) => &x.methods,
+            Self::Unscoped(x) => &x.methods,
         }
     }
 
     pub const fn audit_ids(&self) -> &Vec<String> {
         match self {
-            Self::Unscoped(x) => &x.audit_ids,
-            Self::ProjectScope(x) => &x.audit_ids,
+            Self::ApplicationCredential(x) => &x.audit_ids,
             Self::DomainScope(x) => &x.audit_ids,
             Self::FederationUnscoped(x) => &x.audit_ids,
             Self::FederationProjectScope(x) => &x.audit_ids,
             Self::FederationDomainScope(x) => &x.audit_ids,
-            Self::ApplicationCredential(x) => &x.audit_ids,
+            Self::ProjectScope(x) => &x.audit_ids,
             Self::Restricted(x) => &x.audit_ids,
+            Self::Unscoped(x) => &x.audit_ids,
         }
     }
 
     pub const fn project(&self) -> Option<&Project> {
         match self {
+            Self::ApplicationCredential(x) => x.project.as_ref(),
             Self::ProjectScope(x) => x.project.as_ref(),
             Self::FederationProjectScope(x) => x.project.as_ref(),
             Self::Restricted(x) => x.project.as_ref(),
@@ -181,8 +182,9 @@ impl Token {
 
     pub const fn project_id(&self) -> Option<&String> {
         match self {
-            Self::ProjectScope(x) => Some(&x.project_id),
+            Self::ApplicationCredential(x) => Some(&x.project_id),
             Self::FederationProjectScope(x) => Some(&x.project_id),
+            Self::ProjectScope(x) => Some(&x.project_id),
             Self::Restricted(x) => Some(&x.project_id),
             _ => None,
         }
@@ -198,10 +200,14 @@ impl Token {
 
     pub const fn roles(&self) -> Option<&Vec<Role>> {
         match self {
+            Self::ApplicationCredential(x) => match &x.application_credential {
+                Some(ac) => Some(&ac.roles),
+                None => None,
+            },
             Self::DomainScope(x) => x.roles.as_ref(),
-            Self::ProjectScope(x) => x.roles.as_ref(),
             Self::FederationProjectScope(x) => x.roles.as_ref(),
             Self::FederationDomainScope(x) => x.roles.as_ref(),
+            Self::ProjectScope(x) => x.roles.as_ref(),
             Self::Restricted(x) => x.roles.as_ref(),
             _ => None,
         }
@@ -211,14 +217,14 @@ impl Token {
 impl Validate for Token {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            Self::Unscoped(x) => x.validate(),
+            Self::ApplicationCredential(x) => x.validate(),
             Self::DomainScope(x) => x.validate(),
-            Self::ProjectScope(x) => x.validate(),
             Self::FederationUnscoped(x) => x.validate(),
             Self::FederationProjectScope(x) => x.validate(),
             Self::FederationDomainScope(x) => x.validate(),
-            Self::ApplicationCredential(x) => x.validate(),
+            Self::ProjectScope(x) => x.validate(),
             Self::Restricted(x) => x.validate(),
+            Self::Unscoped(x) => x.validate(),
         }
     }
 }

--- a/src/token/types/application_credential.rs
+++ b/src/token/types/application_credential.rs
@@ -17,9 +17,10 @@ use derive_builder::Builder;
 use serde::Serialize;
 use validator::Validate;
 
-use crate::assignment::types::Role;
+use crate::application_credential::types::ApplicationCredential;
 use crate::identity::types::UserResponse;
 use crate::resource::types::Project;
+use crate::token::TokenProviderError;
 use crate::token::types::Token;
 use crate::token::types::common;
 
@@ -50,7 +51,7 @@ pub struct ApplicationCredentialPayload {
     #[builder(default)]
     pub user: Option<UserResponse>,
     #[builder(default)]
-    pub roles: Vec<Role>,
+    pub application_credential: Option<ApplicationCredential>,
     #[builder(default)]
     pub project: Option<Project>,
 }
@@ -82,5 +83,18 @@ impl ApplicationCredentialPayloadBuilder {
 impl From<ApplicationCredentialPayload> for Token {
     fn from(value: ApplicationCredentialPayload) -> Self {
         Self::ApplicationCredential(value)
+    }
+}
+
+impl ApplicationCredentialPayload {
+    pub fn is_valid(&self) -> Result<bool, TokenProviderError> {
+        if self
+            .application_credential
+            .as_ref()
+            .is_none_or(|ac| ac.project_id != self.project_id)
+        {
+            return Err(TokenProviderError::ApplicationCredentialScopeMismatch);
+        }
+        Ok(true)
     }
 }


### PR DESCRIPTION
For application credential based token roles should be evaluated
(expand) differently: the roles of the application credential without
the roles that the user does not have (anymore).
