### PR TITLE
chore(ci): Skip propose osc change for dependabot PRs

### DIFF
--- a/.github/workflows/propose_osc_changes.yml
+++ b/.github/workflows/propose_osc_changes.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   propose-osc-pr:
-    if: github.event.pull_request.merged == true
+    if: "github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]'"
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
When a dependabot's PR is being merged there is no need to try
propagating changes to `osc` repo
