### PR TITLE
refactor: Replace `db_err` with the context trait

### DIFF
--- a/src/api/v3/role/create.rs
+++ b/src/api/v3/role/create.rs
@@ -52,8 +52,7 @@ pub(super) async fn create(
         .provider
         .get_assignment_provider()
         .create_role(&state, payload.into())
-        .await
-        .map_err(KeystoneApiError::assignment)?;
+        .await?;
 
     // Return response with 201 Created status
     Ok((

--- a/src/api/v3/role/mod.rs
+++ b/src/api/v3/role/mod.rs
@@ -55,8 +55,7 @@ async fn list(
         .provider
         .get_assignment_provider()
         .list_roles(&state, &query.into())
-        .await
-        .map_err(KeystoneApiError::assignment)?
+        .await?
         .into_iter()
         .map(Into::into)
         .collect();

--- a/src/api/v3/role_assignment/mod.rs
+++ b/src/api/v3/role_assignment/mod.rs
@@ -56,8 +56,7 @@ async fn list(
         .provider
         .get_assignment_provider()
         .list_role_assignments(&state, &query.try_into()?)
-        .await
-        .map_err(KeystoneApiError::assignment)?
+        .await?
         .into_iter()
         .map(TryInto::try_into)
         .collect();

--- a/src/api/v3/role_assignment/types.rs
+++ b/src/api/v3/role_assignment/types.rs
@@ -169,12 +169,6 @@ impl From<AssignmentBuilderError> for KeystoneApiError {
     }
 }
 
-impl From<types::RoleAssignmentListParametersBuilderError> for KeystoneApiError {
-    fn from(err: types::RoleAssignmentListParametersBuilderError) -> Self {
-        Self::InternalError(err.to_string())
-    }
-}
-
 /// Assignments
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
 pub struct AssignmentList {

--- a/src/application_credential/backend/sql/application_credential/get.rs
+++ b/src/application_credential/backend/sql/application_credential/get.rs
@@ -16,7 +16,7 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
 
-use crate::application_credential::backend::error::{ApplicationCredentialDatabaseError, db_err};
+use crate::application_credential::backend::error::ApplicationCredentialDatabaseError;
 use crate::application_credential::types::*;
 use crate::assignment::types::Role;
 use crate::db::entity::{
@@ -26,6 +26,7 @@ use crate::db::entity::{
         Role as DbRole,
     },
 };
+use crate::error::DbContextExt;
 
 /// Get application credential by the ID.
 pub async fn get<I: AsRef<str>>(
@@ -38,7 +39,7 @@ pub async fn get<I: AsRef<str>>(
     if let Some(ref entry) = select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching application credential by id"))?
+        .context("fetching application credential by id")?
     {
         let mut builder: ApplicationCredentialBuilder = entry.try_into()?;
         // Query roles and rules in parallel
@@ -48,12 +49,12 @@ pub async fn get<I: AsRef<str>>(
         );
 
         let roles = roles_handle
-            .map_err(|err| db_err(err, "fetching application credential roles"))?
+            .context("fetching application credential roles")?
             .into_iter()
             .map(TryInto::<Role>::try_into)
             .collect::<Result<Vec<Role>, _>>()?;
         let rules = rules_handle
-            .map_err(|err| db_err(err, "fetching application credential rules"))?
+            .context("fetching application credential rules")?
             .into_iter()
             .map(TryInto::<AccessRule>::try_into)
             .collect::<Result<Vec<AccessRule>, _>>()?;

--- a/src/application_credential/types/access_rule.rs
+++ b/src/application_credential/types/access_rule.rs
@@ -17,8 +17,11 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+use crate::error::BuilderError;
+
 /// The application credential access rule object.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct AccessRule {
     /// The ID of the access rule.
@@ -50,6 +53,7 @@ pub struct AccessRule {
 
 /// The application credential access rule object to be created.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct AccessRuleCreate {
     /// The ID of the access rule.

--- a/src/assignment/backend.rs
+++ b/src/assignment/backend.rs
@@ -22,17 +22,7 @@ use crate::assignment::AssignmentProviderError;
 use crate::config::Config;
 use crate::keystone::ServiceState;
 
-pub use crate::assignment::types::assignment::{
-    Assignment, AssignmentBuilder, AssignmentBuilderError, AssignmentType,
-    RoleAssignmentListForMultipleActorTargetParameters,
-    RoleAssignmentListForMultipleActorTargetParametersBuilder, RoleAssignmentListParameters,
-    RoleAssignmentListParametersBuilder, RoleAssignmentListParametersBuilderError,
-    RoleAssignmentTarget,
-};
-pub use crate::assignment::types::role::{
-    Role, RoleBuilder, RoleBuilderError, RoleCreate, RoleListParameters,
-};
-
+use crate::assignment::types::{assignment::*, role::*};
 pub use sql::SqlBackend;
 
 #[async_trait]

--- a/src/assignment/backend/sql/assignment/check.rs
+++ b/src/assignment/backend/sql/assignment/check.rs
@@ -17,7 +17,7 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
 
-use crate::assignment::backend::error::{AssignmentDatabaseError, db_err};
+use crate::assignment::backend::error::AssignmentDatabaseError;
 use crate::assignment::types::*;
 use crate::db::entity::{
     assignment as db_assignment,
@@ -25,6 +25,7 @@ use crate::db::entity::{
     sea_orm_active_enums::Type as DbAssignmentType,
     system_assignment as db_system_assignment,
 };
+use crate::error::DbContextExt;
 
 /// Check whether the grant exists.
 ///
@@ -48,7 +49,7 @@ pub async fn check(
             .filter(db_assignment::Column::Inherited.eq(grant.inherited))
             .count(db)
             .await
-            .map_err(|err| db_err(err, "checking grant"))?,
+            .context("checking grant")?,
         t @ AssignmentType::GroupSystem | t @ AssignmentType::UserSystem => {
             DbSystemAssignment::find()
                 .filter(db_system_assignment::Column::RoleId.eq(grant.role_id.as_str()))
@@ -58,7 +59,7 @@ pub async fn check(
                 .filter(db_system_assignment::Column::Inherited.eq(grant.inherited))
                 .count(db)
                 .await
-                .map_err(|err| db_err(err, "checking system grant"))?
+                .context("checking system grant")?
         }
     };
     Ok(count > 0)

--- a/src/assignment/backend/sql/implied_role.rs
+++ b/src/assignment/backend/sql/implied_role.rs
@@ -16,8 +16,9 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::assignment::backend::error::{AssignmentDatabaseError, db_err};
+use crate::assignment::backend::error::AssignmentDatabaseError;
 use crate::db::entity::prelude::ImpliedRole as DbImpliedRole;
+use crate::error::DbContextExt;
 
 /// Build a resolved tree of role inference
 fn expand_implied_roles(
@@ -55,7 +56,7 @@ pub async fn list_rules(
     for imply in DbImpliedRole::find()
         .all(db)
         .await
-        .map_err(|err| db_err(err, "fetching implied roles"))?
+        .context("fetching implied roles")?
     {
         implied_rules
             .entry(imply.prior_role_id)

--- a/src/assignment/backend/sql/role.rs
+++ b/src/assignment/backend/sql/role.rs
@@ -23,7 +23,7 @@ pub use list::get;
 pub use list::list;
 
 use crate::assignment::backend::error::AssignmentDatabaseError;
-use crate::assignment::types::*;
+use crate::assignment::types::role::*;
 use crate::db::entity::role as db_role;
 
 static NULL_DOMAIN_ID: &str = "<<null>>";

--- a/src/assignment/backend/sql/role/create.rs
+++ b/src/assignment/backend/sql/role/create.rs
@@ -17,9 +17,10 @@ use sea_orm::entity::*;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::assignment::backend::error::{AssignmentDatabaseError, db_err};
+use crate::assignment::backend::error::AssignmentDatabaseError;
 use crate::assignment::types::role::{Role, RoleCreate};
 use crate::db::entity::role as db_role;
+use crate::error::DbContextExt;
 
 /// Create a new role
 pub async fn create(
@@ -44,7 +45,7 @@ pub async fn create(
     }
     .insert(db)
     .await
-    .map_err(|err| db_err(err, "creating role"))?
+    .context("creating role")?
     .try_into()
 }
 

--- a/src/assignment/types.rs
+++ b/src/assignment/types.rs
@@ -21,9 +21,7 @@ use crate::assignment::AssignmentProviderError;
 use crate::keystone::ServiceState;
 
 pub use crate::assignment::types::assignment::*;
-pub use crate::assignment::types::role::{
-    Role, RoleBuilder, RoleBuilderError, RoleCreate, RoleListParameters,
-};
+pub use crate::assignment::types::role::{Role, RoleCreate, RoleListParameters};
 
 #[async_trait]
 pub trait AssignmentApi: Send + Sync + Clone {

--- a/src/assignment/types/assignment.rs
+++ b/src/assignment/types/assignment.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::error::BuilderError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -19,23 +20,29 @@ use validator::Validate;
 
 /// The assignment object.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Assignment {
+    /// The actor id.
+    #[validate(length(max = 64))]
+    pub actor_id: String,
+
     /// The role ID.
     #[validate(length(max = 64))]
     pub role_id: String,
+
     /// The role name.
     #[builder(default)]
     #[validate(length(max = 64))]
     pub role_name: Option<String>,
-    /// The actor id.
-    #[validate(length(max = 64))]
-    pub actor_id: String,
+
     /// The target id.
     #[validate(length(max = 64))]
     pub target_id: String,
+
     /// The assignment type.
     pub r#type: AssignmentType,
+
     /// Inherited flag.
     pub inherited: bool,
 }
@@ -72,6 +79,7 @@ impl fmt::Display for AssignmentType {
 
 /// Parameters for listing role assignments for role/target/actor.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct RoleAssignmentListParameters {
     /// Query role assignments filtering results by the role
@@ -117,9 +125,10 @@ pub struct RoleAssignmentListParameters {
 }
 
 /// Querying effective role assignments for list of actors (typically user with
-/// all groups user is member of) on list of targets (exactl project + inherited
-/// from uppoer projects/domain).
+/// all groups user is member of) on list of targets (exact project + inherited
+/// from upper projects/domain).
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct RoleAssignmentListForMultipleActorTargetParameters {
     /// List of actors for which assignments are looked up.

--- a/src/assignment/types/role.rs
+++ b/src/assignment/types/role.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::error::BuilderError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -19,6 +20,7 @@ use validator::Validate;
 
 /// Role representation.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Role {
     /// The role ID.
@@ -42,6 +44,7 @@ pub struct Role {
 
 /// Query parameters for listing roles.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct RoleListParameters {
     /// Filter roles by the domain.
@@ -53,6 +56,7 @@ pub struct RoleListParameters {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct RoleCreate {
     /// The role ID.

--- a/src/catalog/backends.rs
+++ b/src/catalog/backends.rs
@@ -19,7 +19,7 @@ pub mod error;
 pub mod sql;
 
 use crate::catalog::error::CatalogProviderError;
-use crate::catalog::{Endpoint, EndpointListParameters, Service, ServiceListParameters};
+use crate::catalog::types::{Endpoint, EndpointListParameters, Service, ServiceListParameters};
 use crate::config::Config;
 use crate::keystone::ServiceState;
 

--- a/src/catalog/backends/error.rs
+++ b/src/catalog/backends/error.rs
@@ -12,71 +12,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use sea_orm::SqlErr;
 use thiserror::Error;
 
-use crate::catalog::types::*;
+use crate::error::{BuilderError, DatabaseError};
 
 #[derive(Error, Debug)]
 pub enum CatalogDatabaseError {
+    /// Database error.
+    #[error(transparent)]
+    Database {
+        #[from]
+        source: DatabaseError,
+    },
+
     #[error("data serialization error")]
     Serde {
         #[from]
         source: serde_json::Error,
     },
 
-    #[error(transparent)]
-    EndpointBuilder {
-        #[from]
-        source: EndpointBuilderError,
-    },
-
-    #[error(transparent)]
-    ServiceBuilder {
-        #[from]
-        source: ServiceBuilderError,
-    },
-
     #[error("service {0} not found")]
     ServiceNotFound(String),
 
-    /// Conflict
-    #[error("{message}")]
-    Conflict { message: String, context: String },
-
-    /// SqlError
-    #[error("{message}")]
-    Sql { message: String, context: String },
-
-    /// Database error
-    #[error("Database error while {context}")]
-    Database {
-        source: sea_orm::DbErr,
-        context: String,
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        /// The source of the error.
+        #[from]
+        source: BuilderError,
     },
-}
-
-/// Convert the DB error into the [CatalogDatabaseError] with the context
-/// information.
-pub fn db_err(e: sea_orm::DbErr, context: &str) -> CatalogDatabaseError {
-    e.sql_err().map_or_else(
-        || CatalogDatabaseError::Database {
-            source: e,
-            context: context.to_string(),
-        },
-        |err| match err {
-            SqlErr::UniqueConstraintViolation(descr) => CatalogDatabaseError::Conflict {
-                message: descr.to_string(),
-                context: context.to_string(),
-            },
-            SqlErr::ForeignKeyConstraintViolation(descr) => CatalogDatabaseError::Conflict {
-                message: descr.to_string(),
-                context: context.to_string(),
-            },
-            other => CatalogDatabaseError::Sql {
-                message: other.to_string(),
-                context: context.to_string(),
-            },
-        },
-    )
 }

--- a/src/catalog/backends/sql.rs
+++ b/src/catalog/backends/sql.rs
@@ -17,16 +17,17 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
 
-use super::super::types::*;
 use crate::catalog::CatalogProviderError;
 use crate::catalog::backends::CatalogBackend;
-use crate::catalog::backends::error::{CatalogDatabaseError, db_err};
+use crate::catalog::backends::error::CatalogDatabaseError;
+use crate::catalog::types::*;
 use crate::config::Config;
 use crate::db::entity::{
     endpoint as db_endpoint,
     prelude::{Endpoint as DbEndpoint, Service as DbService},
     service as db_service,
 };
+use crate::error::DbContextExt;
 use crate::keystone::ServiceState;
 
 mod endpoint;
@@ -107,7 +108,7 @@ async fn get_catalog(
         .filter(db_endpoint::Column::Enabled.eq(enabled))
         .all(db)
         .await
-        .map_err(|err| db_err(err, "fetching catalog"))?;
+        .context("fetching catalog")?;
 
     let mut res: Vec<(Service, Vec<Endpoint>)> = Vec::new();
     for (srv, db_endpoints) in db_entities.into_iter() {

--- a/src/catalog/backends/sql/endpoint/get.rs
+++ b/src/catalog/backends/sql/endpoint/get.rs
@@ -15,9 +15,10 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
-use crate::catalog::backends::error::{CatalogDatabaseError, db_err};
+use crate::catalog::backends::error::CatalogDatabaseError;
 use crate::catalog::types::*;
-use crate::db::entity::{endpoint as db_endpoint, prelude::Endpoint as DbEndpoint};
+use crate::db::entity::prelude::Endpoint as DbEndpoint;
+use crate::error::DbContextExt;
 
 pub async fn get<I: AsRef<str>>(
     db: &DatabaseConnection,
@@ -25,11 +26,12 @@ pub async fn get<I: AsRef<str>>(
 ) -> Result<Option<Endpoint>, CatalogDatabaseError> {
     let select = DbEndpoint::find_by_id(id.as_ref());
 
-    let entry: Option<db_endpoint::Model> = select
+    select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching service endpoint by id"))?;
-    entry.map(TryInto::try_into).transpose()
+        .context("fetching service endpoint by id")?
+        .map(TryInto::try_into)
+        .transpose()
 }
 
 #[cfg(test)]

--- a/src/catalog/backends/sql/service/get.rs
+++ b/src/catalog/backends/sql/service/get.rs
@@ -14,9 +14,10 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
-use crate::catalog::backends::error::{CatalogDatabaseError, db_err};
+use crate::catalog::backends::error::CatalogDatabaseError;
 use crate::catalog::types::*;
-use crate::db::entity::{prelude::Service as DbService, service as db_service};
+use crate::db::entity::prelude::Service as DbService;
+use crate::error::DbContextExt;
 
 pub async fn get<I: AsRef<str>>(
     db: &DatabaseConnection,
@@ -24,11 +25,12 @@ pub async fn get<I: AsRef<str>>(
 ) -> Result<Option<Service>, CatalogDatabaseError> {
     let select = DbService::find_by_id(id.as_ref());
 
-    let entry: Option<db_service::Model> = select
+    select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching service by ID"))?;
-    entry.map(TryInto::try_into).transpose()
+        .context("fetching service by ID")?
+        .map(TryInto::try_into)
+        .transpose()
 }
 
 #[cfg(test)]

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -36,7 +36,7 @@ pub mod backends;
 pub mod error;
 #[cfg(test)]
 mod mock;
-pub(crate) mod types;
+pub mod types;
 
 use crate::catalog::backends::CatalogBackend;
 use crate::catalog::backends::sql::SqlBackend;
@@ -47,8 +47,9 @@ use crate::plugin_manager::PluginManager;
 
 #[cfg(test)]
 pub use mock::MockCatalogProvider;
+pub use types::CatalogApi;
 
-pub use types::*;
+use types::*;
 
 #[derive(Clone, Debug)]
 pub struct CatalogProvider {

--- a/src/catalog/types.rs
+++ b/src/catalog/types.rs
@@ -18,13 +18,10 @@ pub mod endpoint;
 pub mod service;
 
 use crate::catalog::CatalogProviderError;
-pub use crate::catalog::types::endpoint::{
-    Endpoint, EndpointBuilder, EndpointBuilderError, EndpointListParameters,
-};
-pub use crate::catalog::types::service::{
-    Service, ServiceBuilder, ServiceBuilderError, ServiceListParameters,
-};
 use crate::keystone::ServiceState;
+
+pub use endpoint::*;
+pub use service::*;
 
 #[async_trait]
 pub trait CatalogApi: Send + Sync + Clone {

--- a/src/catalog/types/endpoint.rs
+++ b/src/catalog/types/endpoint.rs
@@ -16,7 +16,10 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Endpoint {
     /// The ID of the endpoint.
@@ -50,6 +53,7 @@ pub struct Endpoint {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct EndpointListParameters {
     /// Filters the response by an interface.

--- a/src/catalog/types/service.rs
+++ b/src/catalog/types/service.rs
@@ -16,7 +16,10 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Service {
     /// Additional service properties
@@ -38,6 +41,7 @@ pub struct Service {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct ServiceListParameters {
     /// Filters the response by a service name.

--- a/src/federation/api/types/identity_provider.rs
+++ b/src/federation/api/types/identity_provider.rs
@@ -23,11 +23,12 @@ use serde_json::Value;
 use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
-use crate::api::KeystoneApiError;
+use crate::error::BuilderError;
 use crate::federation::types;
 
 /// Identity provider data
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProvider {
     /// The ID of the federated identity provider.
@@ -109,6 +110,7 @@ pub struct IdentityProviderResponse {
 
 /// Identity provider data.
 #[derive(Builder, Clone, Default, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderCreate {
     // TODO: add ID
@@ -206,6 +208,7 @@ pub struct IdentityProviderCreate {
 
 /// New identity provider data.
 #[derive(Builder, Clone, Default, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderUpdate {
     /// The new name of the federated identity provider.
@@ -273,6 +276,7 @@ pub struct IdentityProviderUpdate {
 
 /// Identity provider create request
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderCreateRequest {
     /// Identity provider object.
@@ -282,6 +286,7 @@ pub struct IdentityProviderCreateRequest {
 
 /// Identity provider update request
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderUpdateRequest {
     /// Identity provider object.
@@ -361,12 +366,6 @@ impl IntoResponse for types::IdentityProvider {
     }
 }
 
-impl From<IdentityProviderBuilderError> for KeystoneApiError {
-    fn from(err: IdentityProviderBuilderError) -> Self {
-        Self::InternalError(err.to_string())
-    }
-}
-
 /// List of Identity Providers.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
 pub struct IdentityProviderList {
@@ -400,12 +399,6 @@ pub struct IdentityProviderListParameters {
 
     /// Page marker (id of the last entry on the previous page.
     pub marker: Option<String>,
-}
-
-impl From<types::IdentityProviderListParametersBuilderError> for KeystoneApiError {
-    fn from(err: types::IdentityProviderListParametersBuilderError) -> Self {
-        Self::InternalError(err.to_string())
-    }
 }
 
 fn default_list_limit() -> Option<u64> {

--- a/src/federation/api/types/mapping.rs
+++ b/src/federation/api/types/mapping.rs
@@ -25,10 +25,12 @@ use uuid::Uuid;
 use validator::Validate;
 
 use crate::api::KeystoneApiError;
+use crate::error::BuilderError;
 use crate::federation::types;
 
 /// OIDC/JWT mapping data.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Mapping {
     /// Attribute mapping ID for federated logins.
@@ -119,6 +121,7 @@ pub struct MappingResponse {
 
 /// OIDC/JWT attribute mapping create data.
 #[derive(Builder, Clone, Default, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct MappingCreate {
     /// Attribute mapping ID for federated logins.
@@ -225,6 +228,7 @@ pub struct MappingCreate {
 
 /// OIDC/JWT attribute mapping update data.
 #[derive(Builder, Clone, Default, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(into))]
 pub struct MappingUpdate {
     /// Attribute mapping name for federated logins.
@@ -327,6 +331,7 @@ pub struct MappingUpdate {
 
 /// OIDC/JWT attribute mapping create request.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct MappingCreateRequest {
     /// Mapping object
@@ -336,6 +341,7 @@ pub struct MappingCreateRequest {
 
 /// OIDC/JWT attribute mapping update request.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct MappingUpdateRequest {
     /// Mapping object
@@ -425,12 +431,6 @@ impl IntoResponse for types::Mapping {
     }
 }
 
-impl From<MappingBuilderError> for KeystoneApiError {
-    fn from(err: MappingBuilderError) -> Self {
-        Self::InternalError(err.to_string())
-    }
-}
-
 /// Attribute mapping type.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
@@ -494,12 +494,6 @@ pub struct MappingListParameters {
     /// Filters the response by a mapping type.
     #[param(nullable = false)]
     pub r#type: Option<MappingType>,
-}
-
-impl From<types::MappingListParametersBuilderError> for KeystoneApiError {
-    fn from(err: types::MappingListParametersBuilderError) -> Self {
-        Self::InternalError(err.to_string())
-    }
 }
 
 impl TryFrom<MappingListParameters> for types::MappingListParameters {

--- a/src/federation/backend/sql/auth_state/create.rs
+++ b/src/federation/backend/sql/auth_state/create.rs
@@ -16,7 +16,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::federated_auth_state as db_federated_auth_state;
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn create(
@@ -42,7 +43,7 @@ pub async fn create(
     let db_entry: db_federated_auth_state::Model = entry
         .insert(db)
         .await
-        .map_err(|err| db_err(err, "persisting federation login auth_state"))?;
+        .context("persisting federation login auth_state")?;
 
     db_entry.try_into()
 }

--- a/src/federation/backend/sql/auth_state/delete.rs
+++ b/src/federation/backend/sql/auth_state/delete.rs
@@ -21,7 +21,8 @@ use crate::db::entity::{
     federated_auth_state as db_federated_auth_state,
     prelude::FederatedAuthState as DbFederatedAuthState,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 
 pub async fn delete<S: AsRef<str>>(
     db: &DatabaseConnection,
@@ -30,7 +31,7 @@ pub async fn delete<S: AsRef<str>>(
     let res = DbFederatedAuthState::delete_by_id(id.as_ref())
         .exec(db)
         .await
-        .map_err(|err| db_err(err, "deleting federation login auth_state"))?;
+        .context("deleting federation login auth_state")?;
     if res.rows_affected == 1 {
         Ok(())
     } else {
@@ -45,7 +46,7 @@ pub async fn delete_expired(db: &DatabaseConnection) -> Result<(), FederationDat
         .filter(db_federated_auth_state::Column::ExpiresAt.lt(Utc::now()))
         .exec(db)
         .await
-        .map_err(|err| db_err(err, "deleting expired federation login auth_states"))?;
+        .context("deleting expired federation login auth_states")?;
     Ok(())
 }
 

--- a/src/federation/backend/sql/auth_state/get.rs
+++ b/src/federation/backend/sql/auth_state/get.rs
@@ -19,7 +19,8 @@ use crate::db::entity::{
     federated_auth_state as db_federated_auth_state,
     prelude::FederatedAuthState as DbFederatedAuthState,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn get<I: AsRef<str>>(
@@ -31,7 +32,7 @@ pub async fn get<I: AsRef<str>>(
     let entry: Option<db_federated_auth_state::Model> = select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching federation login auth_state by id"))?;
+        .context("fetching federation login auth_state by id")?;
     entry.map(TryInto::try_into).transpose()
 }
 

--- a/src/federation/backend/sql/identity_provider/create.rs
+++ b/src/federation/backend/sql/identity_provider/create.rs
@@ -22,7 +22,8 @@ use crate::db::entity::{
     federation_protocol as db_old_federation_protocol,
     identity_provider as db_old_identity_provider, mapping as db_old_mapping,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn create(
@@ -83,7 +84,7 @@ pub async fn create(
     let db_entry: db_federated_identity_provider::Model = entry
         .insert(db)
         .await
-        .map_err(|err| db_err(err, "persisting new identity provider"))?;
+        .context("persisting new identity provider")?;
 
     // For compatibility reasons add entry for the IDP old-style as well as the
     // protocol to keep constraints working
@@ -96,7 +97,7 @@ pub async fn create(
     }
     .insert(db)
     .await
-    .map_err(|err| db_err(err, "persisting v3 identity provider"))?;
+    .context("persisting v3 identity provider")?;
 
     db_old_federation_protocol::ActiveModel {
         id: Set("oidc".into()),
@@ -106,7 +107,7 @@ pub async fn create(
     }
     .insert(db)
     .await
-    .map_err(|err| db_err(err, "persisting v3 federation oidc protocol"))?;
+    .context("persisting v3 federation oidc protocol")?;
 
     db_old_federation_protocol::ActiveModel {
         id: Set("jwt".into()),
@@ -116,7 +117,7 @@ pub async fn create(
     }
     .insert(db)
     .await
-    .map_err(|err| db_err(err, "persisting v3 federation jwt protocol"))?;
+    .context("persisting v3 federation jwt protocol")?;
 
     db_old_mapping::Entity::insert(db_old_mapping::ActiveModel {
         id: Set("dummy".into()),
@@ -133,7 +134,7 @@ pub async fn create(
     .on_empty_do_nothing()
     .exec(db)
     .await
-    .map_err(|err| db_err(err, "persisting v3 federation mapping"))?;
+    .context("persisting v3 federation mapping")?;
 
     db_entry.try_into()
 }

--- a/src/federation/backend/sql/identity_provider/delete.rs
+++ b/src/federation/backend/sql/identity_provider/delete.rs
@@ -19,7 +19,8 @@ use crate::db::entity::prelude::{
     FederatedIdentityProvider as DbFederatedIdentityProvider,
     IdentityProvider as DbIdentityProvider,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 
 pub async fn delete<S: AsRef<str>>(
     db: &DatabaseConnection,
@@ -28,12 +29,12 @@ pub async fn delete<S: AsRef<str>>(
     let res = DbFederatedIdentityProvider::delete_by_id(id.as_ref())
         .exec(db)
         .await
-        .map_err(|err| db_err(err, "deleting identity provider"))?;
+        .context("deleting identity provider")?;
     if res.rows_affected == 1 {
         DbIdentityProvider::delete_by_id(id.as_ref())
             .exec(db)
             .await
-            .map_err(|err| db_err(err, "deleting v3 identity provider"))?;
+            .context("deleting v3 identity provider")?;
         Ok(())
     } else {
         Err(FederationDatabaseError::IdentityProviderNotFound(

--- a/src/federation/backend/sql/identity_provider/get.rs
+++ b/src/federation/backend/sql/identity_provider/get.rs
@@ -19,7 +19,8 @@ use crate::db::entity::{
     federated_identity_provider as db_federated_identity_provider,
     prelude::FederatedIdentityProvider as DbFederatedIdentityProvider,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn get<I: AsRef<str>>(
@@ -31,7 +32,7 @@ pub async fn get<I: AsRef<str>>(
     let entry: Option<db_federated_identity_provider::Model> = select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching identity provider by id"))?;
+        .context("fetching identity provider by id")?;
     entry.map(TryInto::try_into).transpose()
 }
 #[cfg(test)]

--- a/src/federation/backend/sql/identity_provider/list.rs
+++ b/src/federation/backend/sql/identity_provider/list.rs
@@ -21,7 +21,8 @@ use crate::db::entity::{
     federated_identity_provider as db_federated_identity_provider,
     prelude::FederatedIdentityProvider as DbFederatedIdentityProvider,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 /// Prepare the paginated query for listing identity providers.
@@ -65,7 +66,7 @@ pub async fn list(
     get_list_query(params)?
         .all(db)
         .await
-        .map_err(|err| db_err(err, "listing identity providers"))?
+        .context("listing identity providers")?
         .into_iter()
         .map(TryInto::<IdentityProvider>::try_into)
         .collect()

--- a/src/federation/backend/sql/identity_provider/update.rs
+++ b/src/federation/backend/sql/identity_provider/update.rs
@@ -19,7 +19,8 @@ use crate::db::entity::{
     federated_identity_provider as db_federated_identity_provider,
     prelude::FederatedIdentityProvider as DbFederatedIdentityProvider,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn update<S: AsRef<str>>(
@@ -30,7 +31,7 @@ pub async fn update<S: AsRef<str>>(
     if let Some(current) = DbFederatedIdentityProvider::find_by_id(id.as_ref())
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching current identity provider data for update"))?
+        .context("fetching current identity provider data for update")?
     {
         let mut entry: db_federated_identity_provider::ActiveModel = current.into();
         if let Some(val) = idp.name {
@@ -73,7 +74,7 @@ pub async fn update<S: AsRef<str>>(
         let db_entry: db_federated_identity_provider::Model = entry
             .update(db)
             .await
-            .map_err(|err| db_err(err, "updating identity provider"))?;
+            .context("updating identity provider")?;
         db_entry.try_into()
     } else {
         Err(FederationDatabaseError::IdentityProviderNotFound(

--- a/src/federation/backend/sql/mapping/delete.rs
+++ b/src/federation/backend/sql/mapping/delete.rs
@@ -16,7 +16,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::prelude::FederatedMapping as DbFederatedMapping;
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 
 pub async fn delete<S: AsRef<str>>(
     db: &DatabaseConnection,
@@ -25,7 +26,7 @@ pub async fn delete<S: AsRef<str>>(
     let res = DbFederatedMapping::delete_by_id(id.as_ref())
         .exec(db)
         .await
-        .map_err(|err| db_err(err, "deleting federation mapping by id"))?;
+        .context("deleting federation mapping by id")?;
     if res.rows_affected == 1 {
         Ok(())
     } else {

--- a/src/federation/backend/sql/mapping/get.rs
+++ b/src/federation/backend/sql/mapping/get.rs
@@ -18,7 +18,8 @@ use sea_orm::entity::*;
 use crate::db::entity::{
     federated_mapping as db_federated_mapping, prelude::FederatedMapping as DbFederatedMapping,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn get<I: AsRef<str>>(
@@ -30,7 +31,7 @@ pub async fn get<I: AsRef<str>>(
     let entry: Option<db_federated_mapping::Model> = select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching federation mapping by id"))?;
+        .context("fetching federation mapping by id")?;
     entry.map(TryInto::try_into).transpose()
 }
 

--- a/src/federation/backend/sql/mapping/list.rs
+++ b/src/federation/backend/sql/mapping/list.rs
@@ -20,7 +20,8 @@ use crate::db::entity::{
     federated_mapping as db_federated_mapping, prelude::FederatedMapping as DbFederatedMapping,
     sea_orm_active_enums::MappingType as db_mapping_type,
 };
-use crate::federation::backend::error::{FederationDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::federation::backend::error::FederationDatabaseError;
 use crate::federation::types::*;
 
 pub async fn list(
@@ -45,10 +46,8 @@ pub async fn list(
         select = select.filter(db_federated_mapping::Column::r#Type.eq(db_mapping_type::from(val)));
     }
 
-    let db_entities: Vec<db_federated_mapping::Model> = select
-        .all(db)
-        .await
-        .map_err(|err| db_err(err, "fetching mappings"))?;
+    let db_entities: Vec<db_federated_mapping::Model> =
+        select.all(db).await.context("fetching mappings")?;
     let results: Result<Vec<Mapping>, _> = db_entities
         .into_iter()
         .map(TryInto::<Mapping>::try_into)

--- a/src/federation/types/auth_state.rs
+++ b/src/federation/types/auth_state.rs
@@ -17,8 +17,10 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use crate::common::types::Scope;
+use crate::error::BuilderError;
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct AuthState {
     /// Timestamp when the auth will expire.

--- a/src/federation/types/identity_provider.rs
+++ b/src/federation/types/identity_provider.rs
@@ -16,8 +16,11 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 /// Identity provider resource.
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProvider {
     /// Federation provider ID.
@@ -68,6 +71,7 @@ pub struct IdentityProvider {
 
 /// New Identity provider data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderCreate {
     /// Federation provider ID.
@@ -118,6 +122,7 @@ pub struct IdentityProviderCreate {
 
 /// Identity provider update data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(into))]
 pub struct IdentityProviderUpdate {
     /// Provider name
@@ -159,6 +164,7 @@ pub struct IdentityProviderUpdate {
 
 /// Identity provider list request.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderListParameters {
     /// Filters the response by IDP name.

--- a/src/federation/types/mapping.rs
+++ b/src/federation/types/mapping.rs
@@ -16,8 +16,11 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 /// Attribute mapping data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Mapping {
     /// Federation IDP attribute mapping ID.
@@ -89,6 +92,7 @@ pub struct Mapping {
 
 /// Update attribute mapping data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(into))]
 pub struct MappingUpdate {
     /// Attribute mapping name.
@@ -164,6 +168,7 @@ pub enum MappingType {
 
 /// List attribute mappings request.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct MappingListParameters {
     /// Filters the response by Mapping name.

--- a/src/identity/backends/sql.rs
+++ b/src/identity/backends/sql.rs
@@ -31,7 +31,7 @@ use crate::auth::AuthenticatedInfo;
 use crate::config::Config;
 use crate::identity::IdentityProviderError;
 use crate::identity::backends::IdentityBackend;
-use crate::identity::backends::error::{IdentityDatabaseError, db_err};
+use crate::identity::backends::error::IdentityDatabaseError;
 use crate::keystone::ServiceState;
 
 #[derive(Clone, Debug, Default)]

--- a/src/identity/backends/sql/federated_user/create.rs
+++ b/src/identity/backends/sql/federated_user/create.rs
@@ -17,7 +17,8 @@ use sea_orm::entity::*;
 
 use crate::config::Config;
 use crate::db::entity::federated_user;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 pub async fn create<A, C>(
     _conf: &Config,
@@ -28,11 +29,11 @@ where
     A: Into<federated_user::ActiveModel>,
     C: ConnectionTrait,
 {
-    federation
+    Ok(federation
         .into()
         .insert(db)
         .await
-        .map_err(|err| db_err(err, "persisting federated user data"))
+        .context("persisting federated user data")?)
 }
 
 #[cfg(test)]

--- a/src/identity/backends/sql/federated_user/find.rs
+++ b/src/identity/backends/sql/federated_user/find.rs
@@ -18,7 +18,8 @@ use sea_orm::query::*;
 
 use crate::config::Config;
 use crate::db::entity::{federated_user, prelude::FederatedUser};
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 /// Get federated user entry by the idp_id and the unique_id
 pub async fn find_by_idp_and_unique_id<I: AsRef<str>, U: AsRef<str>>(
@@ -32,7 +33,7 @@ pub async fn find_by_idp_and_unique_id<I: AsRef<str>, U: AsRef<str>>(
         .filter(federated_user::Column::UniqueId.eq(unique_id.as_ref()))
         .all(db)
         .await
-        .map_err(|err| db_err(err, "searching federated user by the idp and unique id"))?
+        .context("searching federated user by the idp and unique id")?
         .first()
         .cloned())
 }

--- a/src/identity/backends/sql/group/create.rs
+++ b/src/identity/backends/sql/group/create.rs
@@ -17,8 +17,9 @@ use sea_orm::entity::*;
 use serde_json::json;
 
 use crate::db::entity::group;
+use crate::error::DbContextExt;
 use crate::identity::Config;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::identity::backends::sql::IdentityDatabaseError;
 use crate::identity::types::{Group, GroupCreate};
 
 pub async fn create(
@@ -39,7 +40,7 @@ pub async fn create(
     let db_entry: group::Model = entry
         .insert(db)
         .await
-        .map_err(|err| db_err(err, "persisting new group record"))?;
+        .context("persisting new group record")?;
 
     Ok(db_entry.into())
 }

--- a/src/identity/backends/sql/group/delete.rs
+++ b/src/identity/backends/sql/group/delete.rs
@@ -16,8 +16,9 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::prelude::Group as DbGroup;
+use crate::error::DbContextExt;
 use crate::identity::Config;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 pub async fn delete<S: AsRef<str>>(
     _conf: &Config,
@@ -27,7 +28,7 @@ pub async fn delete<S: AsRef<str>>(
     let res = DbGroup::delete_by_id(group_id.as_ref())
         .exec(db)
         .await
-        .map_err(|err| db_err(err, "removing group record"))?;
+        .context("removing group record")?;
     if res.rows_affected == 1 {
         Ok(())
     } else {

--- a/src/identity/backends/sql/group/get.rs
+++ b/src/identity/backends/sql/group/get.rs
@@ -16,8 +16,9 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::prelude::Group as DbGroup;
+use crate::error::DbContextExt;
 use crate::identity::Config;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::identity::backends::sql::IdentityDatabaseError;
 use crate::identity::types::Group;
 
 pub async fn get<S: AsRef<str>>(
@@ -28,7 +29,7 @@ pub async fn get<S: AsRef<str>>(
     Ok(DbGroup::find_by_id(group_id.as_ref())
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching group data"))?
+        .context("fetching group data")?
         .map(Into::into))
 }
 

--- a/src/identity/backends/sql/group/list.rs
+++ b/src/identity/backends/sql/group/list.rs
@@ -17,8 +17,9 @@ use sea_orm::entity::*;
 use sea_orm::query::*;
 
 use crate::db::entity::{group, prelude::Group as DbGroup};
+use crate::error::DbContextExt;
 use crate::identity::Config;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::identity::backends::sql::IdentityDatabaseError;
 use crate::identity::types::{Group, GroupListParameters};
 
 pub async fn list(
@@ -36,13 +37,13 @@ pub async fn list(
         group_select = group_select.filter(group::Column::Name.eq(name));
     }
 
-    let db_groups: Vec<group::Model> = group_select
+    Ok(group_select
         .all(db)
         .await
-        .map_err(|err| db_err(err, "listing groups"))?;
-    let results: Vec<Group> = db_groups.into_iter().map(Into::into).collect();
-
-    Ok(results)
+        .context("listing groups")?
+        .into_iter()
+        .map(Into::into)
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/identity/backends/sql/local_user/create.rs
+++ b/src/identity/backends/sql/local_user/create.rs
@@ -18,7 +18,8 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::db::entity::local_user;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 use crate::identity::types::UserCreate;
 
 pub async fn create<C>(
@@ -29,7 +30,7 @@ pub async fn create<C>(
 where
     C: ConnectionTrait,
 {
-    local_user::ActiveModel {
+    Ok(local_user::ActiveModel {
         id: NotSet,
         user_id: Set(user
             .id
@@ -51,5 +52,5 @@ where
     }
     .insert(db)
     .await
-    .map_err(|err| db_err(err, "inserting new user record"))
+    .context("inserting new user record")?)
 }

--- a/src/identity/backends/sql/local_user/get.rs
+++ b/src/identity/backends/sql/local_user/get.rs
@@ -18,7 +18,8 @@ use sea_orm::query::*;
 
 use crate::config::Config;
 use crate::db::entity::{local_user, prelude::LocalUser};
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
     _conf: &Config,
@@ -26,12 +27,12 @@ pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
     name: N,
     domain_id: D,
 ) -> Result<Option<local_user::Model>, IdentityDatabaseError> {
-    LocalUser::find()
+    Ok(LocalUser::find()
         .filter(local_user::Column::Name.eq(name.as_ref()))
         .filter(local_user::Column::DomainId.eq(domain_id.as_ref()))
         .one(db)
         .await
-        .map_err(|err| db_err(err, "searching user by name and domain"))
+        .context("searching user by name and domain")?)
 }
 
 pub async fn get_by_user_id<U: AsRef<str>>(
@@ -39,9 +40,9 @@ pub async fn get_by_user_id<U: AsRef<str>>(
     db: &DatabaseConnection,
     user_id: U,
 ) -> Result<Option<local_user::Model>, IdentityDatabaseError> {
-    LocalUser::find()
+    Ok(LocalUser::find()
         .filter(local_user::Column::UserId.eq(user_id.as_ref()))
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching the user by ID"))
+        .context("fetching the user by ID")?)
 }

--- a/src/identity/backends/sql/local_user/load.rs
+++ b/src/identity/backends/sql/local_user/load.rs
@@ -21,7 +21,8 @@ use crate::db::entity::{
     local_user, password,
     prelude::{LocalUser, Password},
 };
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 /// Load local user record with passwords from database
 pub async fn load_local_user_with_passwords<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
@@ -54,7 +55,7 @@ pub async fn load_local_user_with_passwords<S1: AsRef<str>, S2: AsRef<str>, S3: 
         .order_by(password::Column::CreatedAtInt, Order::Desc)
         .all(db)
         .await
-        .map_err(|err| db_err(err, "fetching user with passwords"))?;
+        .context("fetching user with passwords")?;
     Ok(results.first().cloned())
 }
 
@@ -76,7 +77,7 @@ pub async fn load_local_users_passwords<L: IntoIterator<Item = Option<i32>>>(
         .order_by(password::Column::CreatedAtInt, Order::Desc)
         .all(db)
         .await
-        .map_err(|err| db_err(err, "fetching user passwords"))?;
+        .context("fetching user passwords")?;
 
     // Prepare hashmap of passwords per local_user_id from requested users
     let mut hashmap: HashMap<i32, Vec<password::Model>> =

--- a/src/identity/backends/sql/local_user/set.rs
+++ b/src/identity/backends/sql/local_user/set.rs
@@ -16,7 +16,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::local_user as db_local_user;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 pub async fn reset_failed_auth(
     db: &DatabaseConnection,
@@ -25,8 +26,8 @@ pub async fn reset_failed_auth(
     let mut update: db_local_user::ActiveModel = user.clone().into();
     update.failed_auth_count = Set(None);
     update.failed_auth_at = Set(None);
-    update
+    Ok(update
         .update(db)
         .await
-        .map_err(|err| db_err(err, "resetting local user failed auth counters"))
+        .context("resetting local user failed auth counters")?)
 }

--- a/src/identity/backends/sql/password/create.rs
+++ b/src/identity/backends/sql/password/create.rs
@@ -17,7 +17,8 @@ use sea_orm::ConnectionTrait;
 use sea_orm::entity::*;
 
 use crate::db::entity::password;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 pub async fn create<C: ConnectionTrait, S: AsRef<str>>(
     db: &C,
@@ -26,7 +27,7 @@ pub async fn create<C: ConnectionTrait, S: AsRef<str>>(
     expires_at: Option<DateTime<Utc>>,
 ) -> Result<password::Model, IdentityDatabaseError> {
     let now = Utc::now().naive_utc();
-    password::ActiveModel {
+    Ok(password::ActiveModel {
         id: NotSet,
         local_user_id: Set(local_user_id),
         self_service: Set(false),
@@ -42,5 +43,5 @@ pub async fn create<C: ConnectionTrait, S: AsRef<str>>(
     }
     .insert(db)
     .await
-    .map_err(|err| db_err(err, "inserting new password record"))
+    .context("inserting new password record")?)
 }

--- a/src/identity/backends/sql/user/delete.rs
+++ b/src/identity/backends/sql/user/delete.rs
@@ -17,7 +17,8 @@ use sea_orm::entity::*;
 
 use crate::config::Config;
 use crate::db::entity::prelude::User as DbUser;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 pub async fn delete<U: AsRef<str>>(
     _conf: &Config,
@@ -27,7 +28,7 @@ pub async fn delete<U: AsRef<str>>(
     let res = DbUser::delete_by_id(user_id.as_ref())
         .exec(db)
         .await
-        .map_err(|err| db_err(err, "deleting the user record"))?;
+        .context("deleting the user record")?;
     if res.rows_affected == 1 {
         Ok(())
     } else {

--- a/src/identity/backends/sql/user/set.rs
+++ b/src/identity/backends/sql/user/set.rs
@@ -18,7 +18,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::user as db_user;
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 /// Reset the `user.last_active_at` to the current date.
 pub async fn reset_last_active(
@@ -27,10 +28,10 @@ pub async fn reset_last_active(
 ) -> Result<db_user::Model, IdentityDatabaseError> {
     let mut update: db_user::ActiveModel = user.clone().into();
     update.last_active_at = Set(Some(Utc::now().date_naive()));
-    update
+    Ok(update
         .update(db)
         .await
-        .map_err(|err| db_err(err, "resetting user's last_active_at"))
+        .context("resetting user's last_active_at")?)
 }
 
 #[cfg(test)]

--- a/src/identity/backends/sql/user_group/add.rs
+++ b/src/identity/backends/sql/user_group/add.rs
@@ -21,7 +21,8 @@ use crate::db::entity::{
     prelude::{ExpiringUserGroupMembership, UserGroupMembership},
     user_group_membership,
 };
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 /// Add the user to the single group.
 pub async fn add_user_to_group<U: AsRef<str>, G: AsRef<str>>(
@@ -35,7 +36,7 @@ pub async fn add_user_to_group<U: AsRef<str>, G: AsRef<str>>(
     }
     .insert(db)
     .await
-    .map_err(|e| db_err(e, "adding user to single group"))?;
+    .context("adding user to single group")?;
 
     Ok(())
 }
@@ -60,7 +61,7 @@ where
     .on_empty_do_nothing()
     .exec(db)
     .await
-    .map_err(|e| db_err(e, "adding user to groups"))?;
+    .context("adding user to groups")?;
 
     Ok(())
 }
@@ -81,7 +82,7 @@ pub async fn add_user_to_group_expiring<U: AsRef<str>, G: AsRef<str>, IDP: AsRef
     }
     .insert(db)
     .await
-    .map_err(|e| db_err(e, "adding user to single group with expiration"))?;
+    .context("adding user to single group with expiration")?;
 
     Ok(())
 }
@@ -112,7 +113,7 @@ where
     .on_empty_do_nothing()
     .exec(db)
     .await
-    .map_err(|e| db_err(e, "adding user to groups with expiration"))?;
+    .context("adding user to groups with expiration")?;
 
     Ok(())
 }

--- a/src/identity/backends/sql/user_group/list.rs
+++ b/src/identity/backends/sql/user_group/list.rs
@@ -21,7 +21,8 @@ use crate::db::entity::{
     expiring_user_group_membership, group as db_group, prelude::Group as DbGroup,
     user_group_membership,
 };
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 use crate::identity::types::Group;
 
 /// List all groups the user is member of.
@@ -60,7 +61,7 @@ pub async fn list_user_groups<S: AsRef<str>>(
         .distinct()
         .all(db)
         .await
-        .map_err(|e| db_err(e, "listing groups the user is currently in"))?
+        .context("listing groups the user is currently in")?
         .into_iter()
         .map(Into::into)
         .collect();

--- a/src/identity/backends/sql/user_group/remove.rs
+++ b/src/identity/backends/sql/user_group/remove.rs
@@ -21,7 +21,8 @@ use crate::db::entity::{
     prelude::{ExpiringUserGroupMembership, UserGroupMembership},
     user_group_membership,
 };
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 /// Remove the user from the group.
 pub async fn remove_user_from_group<U: AsRef<str>, G: AsRef<str>>(
@@ -32,7 +33,7 @@ pub async fn remove_user_from_group<U: AsRef<str>, G: AsRef<str>>(
     UserGroupMembership::delete_by_id((user_id.as_ref().into(), group_id.as_ref().into()))
         .exec(db)
         .await
-        .map_err(|e| db_err(e, "Deleting user<->group membership relation"))?;
+        .context("Deleting user<->group membership relation")?;
 
     Ok(())
 }
@@ -59,7 +60,7 @@ where
         )
         .exec(db)
         .await
-        .map_err(|e| db_err(e, "Deleting user<->group membership relations"))?;
+        .context("Deleting user<->group membership relations")?;
 
     Ok(())
 }
@@ -78,7 +79,7 @@ pub async fn remove_user_from_group_expiring<U: AsRef<str>, G: AsRef<str>, IDP: 
     ))
     .exec(db)
     .await
-    .map_err(|e| db_err(e, "Deleting expiring user<->group membership relation"))?;
+    .context("Deleting expiring user<->group membership relation")?;
 
     Ok(())
 }
@@ -108,7 +109,7 @@ where
         )
         .exec(db)
         .await
-        .map_err(|e| db_err(e, "Deleting user<->group membership relations"))?;
+        .context("Deleting user<->group membership relations")?;
 
     Ok(())
 }

--- a/src/identity/backends/sql/user_group/set.rs
+++ b/src/identity/backends/sql/user_group/set.rs
@@ -24,7 +24,8 @@ use crate::db::entity::{
     prelude::{ExpiringUserGroupMembership, UserGroupMembership},
     user_group_membership,
 };
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 
 use super::*;
 
@@ -51,7 +52,7 @@ where
             .filter(user_group_membership::Column::UserId.eq(user_id.as_ref()))
             .all(db)
             .await
-            .map_err(|e| db_err(e, "selecting group memberships of the user"))?
+            .context("selecting group memberships of the user")?
             .into_iter()
             .map(|item| item.group_id),
     );
@@ -111,7 +112,7 @@ where
             .filter(expiring_user_group_membership::Column::IdpId.eq(idp_id.as_ref()))
             .all(db)
             .await
-            .map_err(|e| db_err(e, "selecting expiring group memberships of the user"))?
+            .context("selecting expiring group memberships of the user")?
             .into_iter()
             .map(|item| item.group_id),
     );
@@ -167,7 +168,7 @@ where
         )
         .exec(db)
         .await
-        .map_err(|e| db_err(e, "renewing expiring group memberships of the user"))?;
+        .context("renewing expiring group memberships of the user")?;
 
     Ok(())
 }

--- a/src/identity/backends/sql/user_option/list.rs
+++ b/src/identity/backends/sql/user_option/list.rs
@@ -17,7 +17,8 @@ use sea_orm::entity::*;
 use sea_orm::query::*;
 
 use crate::db::entity::{prelude::UserOption as DbUserOptions, user_option};
-use crate::identity::backends::sql::{IdentityDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::identity::backends::sql::IdentityDatabaseError;
 use crate::identity::types::UserOptions;
 
 pub async fn list_by_user_id<S: AsRef<str>>(
@@ -29,6 +30,6 @@ pub async fn list_by_user_id<S: AsRef<str>>(
             .filter(user_option::Column::UserId.eq(user_id.as_ref()))
             .all(db)
             .await
-            .map_err(|err| db_err(err, "fetching options of the user"))?,
+            .context("fetching options of the user")?,
     ))
 }

--- a/src/identity/error.rs
+++ b/src/identity/error.rs
@@ -15,81 +15,63 @@
 use thiserror::Error;
 
 use crate::common::password_hashing::PasswordHashError;
+use crate::error::BuilderError;
 use crate::identity::backends::error::*;
-use crate::identity::types::*;
 use crate::resource::error::ResourceProviderError;
 
+/// Identity provider error.
 #[derive(Error, Debug)]
 pub enum IdentityProviderError {
-    /// Unsupported driver
-    #[error("unsupported driver {0}")]
-    UnsupportedDriver(String),
-
-    /// Identity provider error
-    #[error("data serialization error")]
-    Serde {
-        #[from]
-        source: serde_json::Error,
-    },
-
-    #[error("user {0} not found")]
-    UserNotFound(String),
-
-    #[error("group {0} not found")]
-    GroupNotFound(String),
-
-    /// Identity provider error
-    #[error(transparent)]
-    IdentityDatabase { source: IdentityDatabaseError },
-
-    #[error(transparent)]
-    UserBuilder {
-        #[from]
-        source: UserResponseBuilderError,
-    },
-
-    #[error(transparent)]
-    UserCreateBuilder {
-        #[from]
-        source: UserCreateBuilderError,
-    },
-
-    #[error(transparent)]
-    FederatedUserBuilder {
-        #[from]
-        source: FederationBuilderError,
-    },
-
-    #[error(transparent)]
-    DomainBuilder {
-        #[from]
-        source: DomainBuilderError,
-    },
-
-    #[error("either user id or user name with user domain id or name must be given")]
-    UserIdOrNameWithDomain,
-
-    #[error("password hashing error")]
-    PasswordHash {
-        #[from]
-        source: PasswordHashError,
-    },
-
+    /// Authentication error.
     #[error(transparent)]
     AuthenticationInfo {
         #[from]
         source: crate::auth::AuthenticationError,
     },
 
+    /// SQL backend error.
+    #[error(transparent)]
+    Backend {
+        /// The source of the error.
+        source: IdentityDatabaseError,
+    },
+
+    /// Conflict.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// The group has not been found.
+    #[error("group {0} not found")]
+    GroupNotFound(String),
+
+    /// Password hashing error.
+    #[error("password hashing error")]
+    PasswordHash {
+        #[from]
+        source: PasswordHashError,
+    },
+
+    /// Resource provider error.
     #[error(transparent)]
     ResourceProvider {
         #[from]
         source: ResourceProviderError,
     },
 
-    /// Conflict.
-    #[error("conflict: {0}")]
-    Conflict(String),
+    /// (de)serialization error.
+    #[error("data serialization error")]
+    Serde {
+        #[from]
+        source: serde_json::Error,
+    },
+
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        /// The source of the error.
+        #[from]
+        source: BuilderError,
+    },
 
     /// Request validation error.
     #[error("request validation error: {}", source)]
@@ -98,15 +80,35 @@ pub enum IdentityProviderError {
         #[from]
         source: validator::ValidationErrors,
     },
+
+    /// Unsupported driver.
+    #[error("unsupported driver {0}")]
+    UnsupportedDriver(String),
+
+    /// User ID or Name with Domain must be specified.
+    #[error("either user id or user name with user domain id or name must be given")]
+    UserIdOrNameWithDomain,
+
+    /// The user has not been found.
+    #[error("user {0} not found")]
+    UserNotFound(String),
 }
 
 impl From<IdentityDatabaseError> for IdentityProviderError {
     fn from(source: IdentityDatabaseError) -> Self {
         match source {
-            IdentityDatabaseError::Conflict { message, .. } => Self::Conflict(message),
+            IdentityDatabaseError::Database { source } => match source {
+                cfl @ crate::error::DatabaseError::Conflict { .. } => {
+                    Self::Conflict(cfl.to_string())
+                }
+                other => Self::Backend {
+                    source: IdentityDatabaseError::Database { source: other },
+                },
+            },
             IdentityDatabaseError::UserNotFound(x) => Self::UserNotFound(x),
             IdentityDatabaseError::GroupNotFound(x) => Self::GroupNotFound(x),
             IdentityDatabaseError::Serde { source } => Self::Serde { source },
+            IdentityDatabaseError::StructBuilder { source } => Self::StructBuilder { source },
             IdentityDatabaseError::PasswordHash { source } => Self::PasswordHash { source },
             IdentityDatabaseError::NoPasswordHash(..) => Self::AuthenticationInfo {
                 source: crate::auth::AuthenticationError::UserNameOrPasswordWrong,
@@ -114,10 +116,7 @@ impl From<IdentityDatabaseError> for IdentityProviderError {
             IdentityDatabaseError::AuthenticationInfo { source } => {
                 Self::AuthenticationInfo { source }
             }
-            //IdentityDatabaseError::UserLocked(x) => Self::AuthenticationInfo {
-            //    source: crate::auth::AuthenticationError::UserLocked(x),
-            //},
-            _ => Self::IdentityDatabase { source },
+            _ => Self::Backend { source },
         }
     }
 }

--- a/src/identity/types/group.rs
+++ b/src/identity/types/group.rs
@@ -16,7 +16,10 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 #[derive(Builder, Clone, Debug, Default, Deserialize, Eq, Hash, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Group {
     /// The description of the group.
@@ -33,6 +36,7 @@ pub struct Group {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct GroupListParameters {
     /// Filter groups by the domain
@@ -42,6 +46,7 @@ pub struct GroupListParameters {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct GroupCreate {
     /// The description of the group.

--- a/src/identity/types/user.rs
+++ b/src/identity/types/user.rs
@@ -18,7 +18,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use validator::Validate;
 
+use crate::error::BuilderError;
+
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct UserResponse {
     /// The ID of the default project for the user. A user’s default project
@@ -65,6 +68,7 @@ pub struct UserResponse {
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct UserCreate {
     #[builder(default)]
@@ -104,6 +108,7 @@ pub struct UserCreate {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(into))]
 pub struct UserUpdate {
     /// The ID of the default project for the user.
@@ -139,6 +144,7 @@ pub struct UserUpdate {
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct UserOptions {
     pub ignore_change_password_upon_first_use: Option<bool>,
@@ -152,6 +158,7 @@ pub struct UserOptions {
 
 /// User federation data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Federation {
     /// Identity provider ID.
@@ -169,6 +176,7 @@ pub struct Federation {
 
 /// Federation protocol data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct FederationProtocol {
     /// Federation protocol ID.
@@ -182,6 +190,7 @@ pub struct FederationProtocol {
 
 /// User listing parameters.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 pub struct UserListParameters {
     /// Filter users by the domain.
     #[builder(default)]
@@ -199,6 +208,7 @@ pub struct UserListParameters {
 
 /// User password information.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct UserPasswordAuthRequest {
     /// User ID.
@@ -221,6 +231,7 @@ pub struct UserPasswordAuthRequest {
 
 /// Domain information.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Domain {
     /// Domain ID

--- a/src/resource/backend/sql/domain/get.rs
+++ b/src/resource/backend/sql/domain/get.rs
@@ -17,8 +17,9 @@ use sea_orm::entity::*;
 use sea_orm::query::*;
 
 use crate::db::entity::{prelude::Project as DbProject, project as db_project};
+use crate::error::DbContextExt;
 use crate::resource::Config;
-use crate::resource::backend::error::{ResourceDatabaseError, db_err};
+use crate::resource::backend::error::ResourceDatabaseError;
 use crate::resource::types::Domain;
 
 pub async fn get_domain_by_id<I: AsRef<str>>(
@@ -32,7 +33,7 @@ pub async fn get_domain_by_id<I: AsRef<str>>(
     let domain_entry: Option<db_project::Model> = domain_select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching domain by id"))?;
+        .context("fetching domain by id")?;
     domain_entry.map(TryInto::try_into).transpose()
 }
 
@@ -48,6 +49,6 @@ pub async fn get_domain_by_name<N: AsRef<str>>(
     let domain_entry: Option<db_project::Model> = domain_select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching domain by name"))?;
+        .context("fetching domain by name")?;
     domain_entry.map(TryInto::try_into).transpose()
 }

--- a/src/resource/backend/sql/project/get.rs
+++ b/src/resource/backend/sql/project/get.rs
@@ -17,8 +17,9 @@ use sea_orm::entity::*;
 use sea_orm::query::*;
 
 use crate::db::entity::{prelude::Project as DbProject, project as db_project};
+use crate::error::DbContextExt;
 use crate::resource::Config;
-use crate::resource::backend::error::{ResourceDatabaseError, db_err};
+use crate::resource::backend::error::ResourceDatabaseError;
 use crate::resource::types::Project;
 
 pub async fn get_project<I: AsRef<str>>(
@@ -32,7 +33,7 @@ pub async fn get_project<I: AsRef<str>>(
     let project_entry: Option<db_project::Model> = project_select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching project by id"))?;
+        .context("fetching project by id")?;
     project_entry.map(TryInto::try_into).transpose()
 }
 
@@ -50,6 +51,6 @@ pub async fn get_project_by_name<N: AsRef<str>, D: AsRef<str>>(
     let project_entry: Option<db_project::Model> = project_select
         .one(db)
         .await
-        .map_err(|err| db_err(err, "fetching project by name and domain"))?;
+        .context("fetching project by name and domain")?;
     project_entry.map(TryInto::try_into).transpose()
 }

--- a/src/resource/backend/sql/project/tree.rs
+++ b/src/resource/backend/sql/project/tree.rs
@@ -16,7 +16,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::prelude::Project as DbProject;
-use crate::resource::backend::error::{ResourceDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::resource::backend::error::ResourceDatabaseError;
 use crate::resource::types::Project;
 
 pub async fn get_project_parents<I: AsRef<str>>(
@@ -29,7 +30,7 @@ pub async fn get_project_parents<I: AsRef<str>>(
         let project = DbProject::find_by_id(pid.clone())
             .one(db)
             .await
-            .map_err(|err| db_err(err, "resolving project parents"))?;
+            .context("resolving project parents")?;
         if pid == id.as_ref() && project.is_none() {
             return Ok(None);
         }

--- a/src/resource/types.rs
+++ b/src/resource/types.rs
@@ -22,8 +22,8 @@ use crate::config::Config;
 use crate::keystone::ServiceState;
 use crate::resource::ResourceProviderError;
 
-pub use crate::resource::types::domain::{Domain, DomainBuilder, DomainBuilderError};
-pub use crate::resource::types::project::{Project, ProjectBuilder, ProjectBuilderError};
+pub use crate::resource::types::domain::{Domain, DomainBuilder};
+pub use crate::resource::types::project::{Project, ProjectBuilder};
 
 #[async_trait]
 pub trait ResourceBackend: DynClone + Send + Sync + std::fmt::Debug {

--- a/src/resource/types/domain.rs
+++ b/src/resource/types/domain.rs
@@ -16,7 +16,10 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Domain {
     /// The domain ID.

--- a/src/resource/types/project.rs
+++ b/src/resource/types/project.rs
@@ -16,7 +16,10 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::BuilderError;
+
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Project {
     /// The project ID.

--- a/src/revoke/backend/sql/list.rs
+++ b/src/revoke/backend/sql/list.rs
@@ -20,7 +20,8 @@ use sea_orm::query::*;
 use crate::db::entity::{
     prelude::RevocationEvent as DbRevocationEvent, revocation_event as db_revocation_event,
 };
-use crate::revoke::backend::error::{RevokeDatabaseError, db_err};
+use crate::error::DbContextExt;
+use crate::revoke::backend::error::RevokeDatabaseError;
 use crate::revoke::types::{RevocationEvent, RevocationEventListParameters};
 
 fn build_query_filters(
@@ -113,10 +114,10 @@ pub async fn count(
     db: &DatabaseConnection,
     params: &RevocationEventListParameters,
 ) -> Result<u64, RevokeDatabaseError> {
-    build_query_filters(params)?
+    Ok(build_query_filters(params)?
         .count(db)
         .await
-        .map_err(|err| db_err(err, "counting revocation events for the token"))
+        .context("counting revocation events for the token")?)
 }
 
 /// List token revocation events.
@@ -131,7 +132,7 @@ pub async fn list(
         build_query_filters(params)?
             .all(db)
             .await
-            .map_err(|err| db_err(err, "listing revocation events for the token"))?;
+            .context("listing revocation events for the token")?;
 
     let results: Result<Vec<RevocationEvent>, _> = db_entities
         .into_iter()

--- a/src/webauthn/driver/credential/create.rs
+++ b/src/webauthn/driver/credential/create.rs
@@ -18,7 +18,8 @@ use sea_orm::entity::*;
 use webauthn_rs::prelude::Passkey;
 
 use crate::db::entity::webauthn_credential;
-use crate::webauthn::{WebauthnError, db_err, types::WebauthnCredential};
+use crate::error::DbContextExt;
+use crate::webauthn::{WebauthnError, types::WebauthnCredential};
 
 pub async fn create<U: AsRef<str>, D: AsRef<str>>(
     db: &DatabaseConnection,
@@ -51,7 +52,7 @@ pub async fn create<U: AsRef<str>, D: AsRef<str>>(
     let cred = entry
         .insert(db)
         .await
-        .map_err(|e| db_err(e, "inserting webauth credential"))?
+        .context("inserting webauthn credential")?
         .into();
     Ok(cred)
 }

--- a/src/webauthn/driver/credential/list.rs
+++ b/src/webauthn/driver/credential/list.rs
@@ -18,7 +18,8 @@ use sea_orm::query::*;
 use webauthn_rs::prelude::Passkey;
 
 use crate::db::entity::{prelude::WebauthnCredential as DbCred, webauthn_credential};
-use crate::webauthn::{WebauthnError, db_err};
+use crate::error::DbContextExt;
+use crate::webauthn::WebauthnError;
 
 pub async fn list<U: AsRef<str>>(
     db: &DatabaseConnection,
@@ -28,7 +29,7 @@ pub async fn list<U: AsRef<str>>(
         .filter(webauthn_credential::Column::UserId.eq(user_id.as_ref()))
         .all(db)
         .await
-        .map_err(|e| db_err(e, "listing webauth credential"))?
+        .context("listing webauthn credential")?
         .into_iter()
         .map(|x| serde_json::from_str::<Passkey>(&x.passkey))
         .collect();

--- a/src/webauthn/driver/state/create.rs
+++ b/src/webauthn/driver/state/create.rs
@@ -18,7 +18,8 @@ use sea_orm::entity::*;
 use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
 use crate::db::entity::webauthn_state;
-use crate::webauthn::{WebauthnError, db_err};
+use crate::error::DbContextExt;
+use crate::webauthn::WebauthnError;
 
 pub async fn create_register<U: AsRef<str>>(
     db: &DatabaseConnection,
@@ -35,7 +36,7 @@ pub async fn create_register<U: AsRef<str>>(
     let _ = entry
         .insert(db)
         .await
-        .map_err(|e| db_err(e, "inserting webauthn registration state record"))?;
+        .context("inserting webauthn registration state record")?;
 
     Ok(())
 }
@@ -55,7 +56,7 @@ pub async fn create_auth<U: AsRef<str>>(
     let _ = entry
         .insert(db)
         .await
-        .map_err(|e| db_err(e, "inserting webauthn auth state record"))?;
+        .context("inserting webauthn auth state record")?;
     Ok(())
 }
 

--- a/src/webauthn/driver/state/delete.rs
+++ b/src/webauthn/driver/state/delete.rs
@@ -16,7 +16,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
 use crate::db::entity::prelude::WebauthnState as DbPasskeyState;
-use crate::webauthn::{WebauthnError, db_err};
+use crate::error::DbContextExt;
+use crate::webauthn::WebauthnError;
 
 pub async fn delete<U: AsRef<str>>(
     db: &DatabaseConnection,
@@ -25,7 +26,7 @@ pub async fn delete<U: AsRef<str>>(
     DbPasskeyState::delete_by_id(user_id.as_ref())
         .exec(db)
         .await
-        .map_err(|e| db_err(e, "deleting webauthn state record"))?;
+        .context("deleting webauthn state record")?;
     Ok(())
 }
 

--- a/src/webauthn/driver/state/get.rs
+++ b/src/webauthn/driver/state/get.rs
@@ -18,7 +18,8 @@ use sea_orm::query::*;
 use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
 use crate::db::entity::{prelude::WebauthnState as DbPasskeyState, webauthn_state};
-use crate::webauthn::error::{WebauthnError, db_err};
+use crate::error::DbContextExt;
+use crate::webauthn::error::WebauthnError;
 
 pub async fn get_register<U: AsRef<str>>(
     db: &DatabaseConnection,
@@ -28,7 +29,7 @@ pub async fn get_register<U: AsRef<str>>(
         .filter(webauthn_state::Column::Type.eq("register"))
         .one(db)
         .await
-        .map_err(|e| db_err(e, "searching for webauthn registration state record"))?
+        .context("searching for webauthn registration state record")?
     {
         Some(rec) => Ok(Some(serde_json::from_str(&rec.state)?)),
         None => Ok(None),
@@ -43,7 +44,7 @@ pub async fn get_auth<U: AsRef<str>>(
         .filter(webauthn_state::Column::Type.eq("auth"))
         .one(db)
         .await
-        .map_err(|e| db_err(e, "searching for webauthn auth state record"))?
+        .context("searching for webauthn auth state record")?
     {
         Some(rec) => Ok(Some(serde_json::from_str(&rec.state)?)),
         None => Ok(None),


### PR DESCRIPTION
Apply the approach similar to the eyre for adding context to the
database errors. This helps reducing amount of the boilerplate code.
