### PR TITLE
feat: Add pagination to the attribute mappings

### DIFF
--- a/src/federation/api/types/mapping.rs
+++ b/src/federation/api/types/mapping.rs
@@ -476,11 +476,6 @@ impl IntoResponse for MappingList {
 /// Query parameters for listing OIDC/JWT attribute mappings.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, IntoParams, Validate)]
 pub struct MappingListParameters {
-    /// Filters the response by IDP name.
-    #[param(nullable = false)]
-    #[validate(length(max = 255))]
-    pub name: Option<String>,
-
     /// Filters the response by a domain ID.
     #[param(nullable = false)]
     #[validate(length(max = 64))]
@@ -490,6 +485,19 @@ pub struct MappingListParameters {
     #[param(nullable = false)]
     #[validate(length(max = 64))]
     pub idp_id: Option<String>,
+
+    /// Filters the response by IDP name.
+    #[param(nullable = false)]
+    #[validate(length(max = 255))]
+    pub name: Option<String>,
+
+    /// Limit number of entries on the single response page (Maximal 100)
+    #[validate(range(min = 1, max = 100))]
+    pub limit: Option<u64>,
+
+    /// Page marker (id of the last entry on the previous page.
+    #[validate(length(max = 64))]
+    pub marker: Option<String>,
 
     /// Filters the response by a mapping type.
     #[param(nullable = false)]
@@ -501,9 +509,11 @@ impl TryFrom<MappingListParameters> for types::MappingListParameters {
 
     fn try_from(value: MappingListParameters) -> Result<Self, Self::Error> {
         Ok(Self {
-            name: value.name,
             domain_id: value.domain_id,
             idp_id: value.idp_id,
+            limit: value.limit,
+            marker: value.marker,
+            name: value.name,
             r#type: value.r#type.map(Into::into),
         })
     }

--- a/src/federation/types/identity_provider.rs
+++ b/src/federation/types/identity_provider.rs
@@ -167,9 +167,6 @@ pub struct IdentityProviderUpdate {
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct IdentityProviderListParameters {
-    /// Filters the response by IDP name.
-    pub name: Option<String>,
-
     /// Filters the response by a domain_id ID. It is an optional list of
     /// optional strings to represent fetching of null and non-null values
     /// in a single request.
@@ -182,4 +179,7 @@ pub struct IdentityProviderListParameters {
     /// Page marker (id of the last entry on the previous page.
     #[builder(default)]
     pub marker: Option<String>,
+    ///
+    /// Filters the response by IDP name.
+    pub name: Option<String>,
 }

--- a/src/federation/types/mapping.rs
+++ b/src/federation/types/mapping.rs
@@ -171,12 +171,23 @@ pub enum MappingType {
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct MappingListParameters {
-    /// Filters the response by Mapping name.
-    pub name: Option<String>,
     /// Filters the response by a domain_id ID.
     pub domain_id: Option<String>,
+
     /// Filters the response by IDP ID.
     pub idp_id: Option<String>,
+
+    /// Limit number of entries on the single response page.
+    #[builder(default)]
+    pub limit: Option<u64>,
+
+    /// Page marker (id of the last entry on the previous page.
+    #[builder(default)]
+    pub marker: Option<String>,
+
+    /// Filters the response by Mapping name.
+    pub name: Option<String>,
+
     /// Filters mappings by the type
     pub r#type: Option<MappingType>,
 }


### PR DESCRIPTION
Extend mapping listing provider with the pagination. The only remaining
thing is the generation of the links to the next page on the api side.
