### PR TITLE
feat: add `identity.get_user_domain_id` method

### DIFF
--- a/src/application_credential/mod.rs
+++ b/src/application_credential/mod.rs
@@ -139,7 +139,6 @@ mod mock;
 pub mod types;
 
 /// Application Credential Provider.
-#[derive(Clone)]
 pub struct ApplicationCredentialProvider {
     backend_driver: Arc<dyn ApplicationCredentialBackend>,
 }

--- a/src/assignment/mod.rs
+++ b/src/assignment/mod.rs
@@ -73,7 +73,6 @@ use crate::resource::ResourceApi;
 pub use mock::MockAssignmentProvider;
 pub use types::AssignmentApi;
 
-#[derive(Clone)]
 pub struct AssignmentProvider {
     backend_driver: Arc<dyn AssignmentBackend>,
 }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -52,7 +52,6 @@ pub use types::CatalogApi;
 
 use types::*;
 
-#[derive(Clone)]
 pub struct CatalogProvider {
     backend_driver: Arc<dyn CatalogBackend>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -263,6 +263,10 @@ pub struct IdentityProvider {
     #[serde(default = "default_sql_driver")]
     pub driver: String,
 
+    /// Caching.
+    #[serde(default)]
+    pub caching: bool,
+
     /// Default password hashing algorithm.
     #[serde(default)]
     pub password_hashing_algorithm: PasswordHashingAlgo,
@@ -282,6 +286,7 @@ impl Default for IdentityProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            caching: false,
             password_hashing_algorithm: PasswordHashingAlgo::Bcrypt,
             max_password_length: 4096,
             password_hash_rounds: None,

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -37,7 +37,6 @@ use types::*;
 pub use mock::MockFederationProvider;
 pub use types::FederationApi;
 
-#[derive(Clone)]
 pub struct FederationProvider {
     backend_driver: Arc<dyn FederationBackend>,
 }

--- a/src/identity/backend.rs
+++ b/src/identity/backend.rs
@@ -27,84 +27,6 @@ pub mod sql;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait IdentityBackend: Send + Sync {
-    /// Authenticate a user by a password.
-    async fn authenticate_by_password(
-        &self,
-        state: &ServiceState,
-        auth: &UserPasswordAuthRequest,
-    ) -> Result<AuthenticatedInfo, IdentityProviderError>;
-
-    /// List Users.
-    async fn list_users(
-        &self,
-        state: &ServiceState,
-        params: &UserListParameters,
-    ) -> Result<Vec<UserResponse>, IdentityProviderError>;
-
-    /// Get single user by ID.
-    async fn get_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<Option<UserResponse>, IdentityProviderError>;
-
-    /// Find federated user by IDP and Unique ID.
-    async fn find_federated_user<'a>(
-        &self,
-        state: &ServiceState,
-        idp_id: &'a str,
-        unique_id: &'a str,
-    ) -> Result<Option<UserResponse>, IdentityProviderError>;
-
-    /// Create user.
-    async fn create_user(
-        &self,
-        state: &ServiceState,
-        user: UserCreate,
-    ) -> Result<UserResponse, IdentityProviderError>;
-
-    /// Delete user.
-    async fn delete_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<(), IdentityProviderError>;
-
-    /// List groups.
-    async fn list_groups(
-        &self,
-        state: &ServiceState,
-        params: &GroupListParameters,
-    ) -> Result<Vec<Group>, IdentityProviderError>;
-
-    /// Get single group by ID.
-    async fn get_group<'a>(
-        &self,
-        state: &ServiceState,
-        group_id: &'a str,
-    ) -> Result<Option<Group>, IdentityProviderError>;
-
-    /// Create group.
-    async fn create_group(
-        &self,
-        state: &ServiceState,
-        group: GroupCreate,
-    ) -> Result<Group, IdentityProviderError>;
-
-    /// Delete group by ID.
-    async fn delete_group<'a>(
-        &self,
-        state: &ServiceState,
-        group_id: &'a str,
-    ) -> Result<(), IdentityProviderError>;
-
-    /// List groups a user is member of.
-    async fn list_groups_of_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<Vec<Group>, IdentityProviderError>;
-
     /// Add the user to the group.
     async fn add_user_to_group<'a>(
         &self,
@@ -136,6 +58,91 @@ pub trait IdentityBackend: Send + Sync {
         memberships: Vec<(&'a str, &'a str)>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
+
+    /// Authenticate a user by a password.
+    async fn authenticate_by_password(
+        &self,
+        state: &ServiceState,
+        auth: &UserPasswordAuthRequest,
+    ) -> Result<AuthenticatedInfo, IdentityProviderError>;
+
+    /// Create group.
+    async fn create_group(
+        &self,
+        state: &ServiceState,
+        group: GroupCreate,
+    ) -> Result<Group, IdentityProviderError>;
+
+    /// Create user.
+    async fn create_user(
+        &self,
+        state: &ServiceState,
+        user: UserCreate,
+    ) -> Result<UserResponse, IdentityProviderError>;
+
+    /// Delete group by ID.
+    async fn delete_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<(), IdentityProviderError>;
+
+    /// Delete user.
+    async fn delete_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<(), IdentityProviderError>;
+
+    /// Get single group by ID.
+    async fn get_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<Option<Group>, IdentityProviderError>;
+
+    /// Get single user by ID.
+    async fn get_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError>;
+
+    /// Get single user by ID.
+    async fn get_user_domain_id<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<String>, IdentityProviderError>;
+
+    /// Find federated user by IDP and Unique ID.
+    async fn find_federated_user<'a>(
+        &self,
+        state: &ServiceState,
+        idp_id: &'a str,
+        unique_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError>;
+
+    /// List groups.
+    async fn list_groups(
+        &self,
+        state: &ServiceState,
+        params: &GroupListParameters,
+    ) -> Result<Vec<Group>, IdentityProviderError>;
+
+    /// List Users.
+    async fn list_users(
+        &self,
+        state: &ServiceState,
+        params: &UserListParameters,
+    ) -> Result<Vec<UserResponse>, IdentityProviderError>;
+
+    /// List groups a user is member of.
+    async fn list_groups_of_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Vec<Group>, IdentityProviderError>;
 
     /// Remove the user from the group.
     async fn remove_user_from_group<'a>(

--- a/src/identity/backend/sql/user.rs
+++ b/src/identity/backend/sql/user.rs
@@ -27,8 +27,8 @@ mod set;
 
 pub use create::create;
 pub use delete::delete;
-pub use get::get;
 pub(super) use get::get_main_entry;
+pub use get::{get, get_user_domain_id};
 pub use list::list;
 pub use set::reset_last_active;
 

--- a/src/identity/mock.rs
+++ b/src/identity/mock.rs
@@ -35,73 +35,6 @@ mock! {
 
     #[async_trait]
     impl IdentityApi for IdentityProvider {
-        async fn authenticate_by_password(
-            &self,
-            state: &ServiceState,
-            auth: &UserPasswordAuthRequest,
-        ) -> Result<AuthenticatedInfo, IdentityProviderError>;
-
-        async fn list_users(
-            &self,
-            state: &ServiceState,
-            params: &UserListParameters,
-        ) -> Result<Vec<UserResponse>, IdentityProviderError>;
-
-        async fn get_user<'a>(
-            &self,
-            state: &ServiceState,
-            user_id: &'a str,
-        ) -> Result<Option<UserResponse>, IdentityProviderError>;
-
-        async fn find_federated_user<'a>(
-            &self,
-            state: &ServiceState,
-            idp_id: &'a str,
-            unique_id: &'a str,
-        ) -> Result<Option<UserResponse>, IdentityProviderError>;
-
-        async fn create_user(
-            &self,
-            state: &ServiceState,
-            user: UserCreate,
-        ) -> Result<UserResponse, IdentityProviderError>;
-
-        async fn delete_user<'a>(
-            &self,
-            state: &ServiceState,
-            user_id: &'a str,
-        ) -> Result<(), IdentityProviderError>;
-
-        async fn list_groups(
-            &self,
-            state: &ServiceState,
-            params: &GroupListParameters,
-        ) -> Result<Vec<Group>, IdentityProviderError>;
-
-        async fn get_group<'a>(
-            &self,
-            state: &ServiceState,
-            group_id: &'a str,
-        ) -> Result<Option<Group>, IdentityProviderError>;
-
-        async fn create_group(
-            &self,
-            state: &ServiceState,
-            group: GroupCreate,
-        ) -> Result<Group, IdentityProviderError>;
-
-        async fn delete_group<'a>(
-            &self,
-            state: &ServiceState,
-            group_id: &'a str,
-        ) -> Result<(), IdentityProviderError>;
-
-        async fn list_groups_of_user<'a>(
-            &self,
-            state: &ServiceState,
-            user_id: &'a str,
-        ) -> Result<Vec<Group>, IdentityProviderError>;
-
         async fn add_user_to_group<'a>(
             &self,
             state: &ServiceState,
@@ -129,6 +62,79 @@ mock! {
             memberships: Vec<(&'a str, &'a str)>,
             idp_id: &'a str
         ) -> Result<(), IdentityProviderError>;
+
+        async fn authenticate_by_password(
+            &self,
+            state: &ServiceState,
+            auth: &UserPasswordAuthRequest,
+        ) -> Result<AuthenticatedInfo, IdentityProviderError>;
+
+        async fn create_group(
+            &self,
+            state: &ServiceState,
+            group: GroupCreate,
+        ) -> Result<Group, IdentityProviderError>;
+
+        async fn create_user(
+            &self,
+            state: &ServiceState,
+            user: UserCreate,
+        ) -> Result<UserResponse, IdentityProviderError>;
+
+        async fn delete_group<'a>(
+            &self,
+            state: &ServiceState,
+            group_id: &'a str,
+        ) -> Result<(), IdentityProviderError>;
+
+        async fn delete_user<'a>(
+            &self,
+            state: &ServiceState,
+            user_id: &'a str,
+        ) -> Result<(), IdentityProviderError>;
+
+        async fn get_group<'a>(
+            &self,
+            state: &ServiceState,
+            group_id: &'a str,
+        ) -> Result<Option<Group>, IdentityProviderError>;
+
+        async fn get_user<'a>(
+            &self,
+            state: &ServiceState,
+            user_id: &'a str,
+        ) -> Result<Option<UserResponse>, IdentityProviderError>;
+
+        async fn get_user_domain_id<'a>(
+            &self,
+            state: &ServiceState,
+            user_id: &'a str,
+        ) -> Result<Option<String>, IdentityProviderError>;
+
+        async fn find_federated_user<'a>(
+            &self,
+            state: &ServiceState,
+            idp_id: &'a str,
+            unique_id: &'a str,
+        ) -> Result<Option<UserResponse>, IdentityProviderError>;
+
+        async fn list_groups(
+            &self,
+            state: &ServiceState,
+            params: &GroupListParameters,
+        ) -> Result<Vec<Group>, IdentityProviderError>;
+
+        async fn list_groups_of_user<'a>(
+            &self,
+            state: &ServiceState,
+            user_id: &'a str,
+        ) -> Result<Vec<Group>, IdentityProviderError>;
+
+        async fn list_users(
+            &self,
+            state: &ServiceState,
+            params: &UserListParameters,
+        ) -> Result<Vec<UserResponse>, IdentityProviderError>;
 
         async fn remove_user_from_group<'a>(
             &self,

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -35,8 +35,9 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use uuid::Uuid;
 use validator::Validate;
 
@@ -62,9 +63,16 @@ use crate::resource::{ResourceApi, error::ResourceProviderError};
 
 pub use types::IdentityApi;
 
-#[derive(Clone)]
+/// Identity provider.
 pub struct IdentityProvider {
     backend_driver: Arc<dyn IdentityBackend>,
+    /// Caching flag. When enabled certain data can be cached (i.e. `domain_id`
+    /// by `user_id`).
+    caching: bool,
+    /// Internal cache of `user_id` to `domain_id` mappings. This information if
+    /// fully static and can never change (well, except with a direct SQL
+    /// update).
+    user_id_domain_id_cache: RwLock<HashMap<String, String>>,
 }
 
 impl IdentityProvider {
@@ -86,164 +94,24 @@ impl IdentityProvider {
                 }
             }
         };
-        Ok(Self { backend_driver })
+        Ok(Self {
+            backend_driver,
+            caching: config.identity.caching,
+            user_id_domain_id_cache: HashMap::new().into(),
+        })
+    }
+
+    pub fn from_driver<I: IdentityBackend + 'static>(driver: I) -> Self {
+        Self {
+            backend_driver: Arc::new(driver),
+            caching: false,
+            user_id_domain_id_cache: HashMap::new().into(),
+        }
     }
 }
 
 #[async_trait]
 impl IdentityApi for IdentityProvider {
-    /// Authenticate user with the password auth method
-    #[tracing::instrument(level = "info", skip(self, state, auth))]
-    async fn authenticate_by_password(
-        &self,
-        state: &ServiceState,
-        auth: &UserPasswordAuthRequest,
-    ) -> Result<AuthenticatedInfo, IdentityProviderError> {
-        let mut auth = auth.clone();
-        if auth.id.is_none() {
-            if auth.name.is_none() {
-                return Err(IdentityProviderError::UserIdOrNameWithDomain);
-            }
-
-            if let Some(ref mut domain) = auth.domain {
-                if let Some(dname) = &domain.name {
-                    let d = state
-                        .provider
-                        .get_resource_provider()
-                        .find_domain_by_name(state, dname)
-                        .await?
-                        .ok_or(ResourceProviderError::DomainNotFound(dname.clone()))?;
-                    domain.id = Some(d.id);
-                } else if domain.id.is_none() {
-                    return Err(IdentityProviderError::UserIdOrNameWithDomain);
-                }
-            } else {
-                return Err(IdentityProviderError::UserIdOrNameWithDomain);
-            }
-        }
-
-        self.backend_driver
-            .authenticate_by_password(state, &auth)
-            .await
-    }
-
-    /// List users
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn list_users(
-        &self,
-        state: &ServiceState,
-        params: &UserListParameters,
-    ) -> Result<impl IntoIterator<Item = UserResponse>, IdentityProviderError> {
-        self.backend_driver.list_users(state, params).await
-    }
-
-    /// Get single user
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn get_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<Option<UserResponse>, IdentityProviderError> {
-        self.backend_driver.get_user(state, user_id).await
-    }
-
-    /// Find federated user by IDP and Unique ID
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn find_federated_user<'a>(
-        &self,
-        state: &ServiceState,
-        idp_id: &'a str,
-        unique_id: &'a str,
-    ) -> Result<Option<UserResponse>, IdentityProviderError> {
-        self.backend_driver
-            .find_federated_user(state, idp_id, unique_id)
-            .await
-    }
-
-    /// Create user
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn create_user(
-        &self,
-        state: &ServiceState,
-        user: UserCreate,
-    ) -> Result<UserResponse, IdentityProviderError> {
-        let mut mod_user = user;
-        if mod_user.id.is_none() {
-            mod_user.id = Some(Uuid::new_v4().simple().to_string());
-        }
-        if mod_user.enabled.is_none() {
-            mod_user.enabled = Some(true);
-        }
-        mod_user.validate()?;
-        self.backend_driver.create_user(state, mod_user).await
-    }
-
-    /// Delete user
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn delete_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<(), IdentityProviderError> {
-        self.backend_driver.delete_user(state, user_id).await
-    }
-
-    /// List groups
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn list_groups(
-        &self,
-        state: &ServiceState,
-        params: &GroupListParameters,
-    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError> {
-        self.backend_driver.list_groups(state, params).await
-    }
-
-    /// Get single group
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn get_group<'a>(
-        &self,
-        state: &ServiceState,
-        group_id: &'a str,
-    ) -> Result<Option<Group>, IdentityProviderError> {
-        self.backend_driver.get_group(state, group_id).await
-    }
-
-    /// Create group
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn create_group(
-        &self,
-        state: &ServiceState,
-        group: GroupCreate,
-    ) -> Result<Group, IdentityProviderError> {
-        let mut res = group;
-        if res.id.is_none() {
-            res.id = Some(Uuid::new_v4().simple().to_string());
-        }
-        self.backend_driver.create_group(state, res).await
-    }
-
-    /// Delete group
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn delete_group<'a>(
-        &self,
-        state: &ServiceState,
-        group_id: &'a str,
-    ) -> Result<(), IdentityProviderError> {
-        self.backend_driver.delete_group(state, group_id).await
-    }
-
-    /// List groups a user is a member of.
-    #[tracing::instrument(level = "info", skip(self, state))]
-    async fn list_groups_of_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError> {
-        self.backend_driver
-            .list_groups_of_user(state, user_id)
-            .await
-    }
-
     #[tracing::instrument(level = "info", skip(self, state))]
     async fn add_user_to_group<'a>(
         &self,
@@ -289,6 +157,207 @@ impl IdentityApi for IdentityProvider {
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
             .add_users_to_groups_expiring(state, memberships, idp_id)
+            .await
+    }
+
+    /// Authenticate user with the password auth method.
+    #[tracing::instrument(level = "info", skip(self, state, auth))]
+    async fn authenticate_by_password(
+        &self,
+        state: &ServiceState,
+        auth: &UserPasswordAuthRequest,
+    ) -> Result<AuthenticatedInfo, IdentityProviderError> {
+        let mut auth = auth.clone();
+        if auth.id.is_none() {
+            if auth.name.is_none() {
+                return Err(IdentityProviderError::UserIdOrNameWithDomain);
+            }
+
+            if let Some(ref mut domain) = auth.domain {
+                if let Some(dname) = &domain.name {
+                    let d = state
+                        .provider
+                        .get_resource_provider()
+                        .find_domain_by_name(state, dname)
+                        .await?
+                        .ok_or(ResourceProviderError::DomainNotFound(dname.clone()))?;
+                    domain.id = Some(d.id);
+                } else if domain.id.is_none() {
+                    return Err(IdentityProviderError::UserIdOrNameWithDomain);
+                }
+            } else {
+                return Err(IdentityProviderError::UserIdOrNameWithDomain);
+            }
+        }
+
+        self.backend_driver
+            .authenticate_by_password(state, &auth)
+            .await
+    }
+
+    /// Create user.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn create_user(
+        &self,
+        state: &ServiceState,
+        user: UserCreate,
+    ) -> Result<UserResponse, IdentityProviderError> {
+        let mut mod_user = user;
+        if mod_user.id.is_none() {
+            mod_user.id = Some(Uuid::new_v4().simple().to_string());
+        }
+        if mod_user.enabled.is_none() {
+            mod_user.enabled = Some(true);
+        }
+        mod_user.validate()?;
+        self.backend_driver.create_user(state, mod_user).await
+    }
+
+    /// Delete group.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn delete_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        self.backend_driver.delete_group(state, group_id).await
+    }
+
+    /// Delete user.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn delete_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        self.backend_driver.delete_user(state, user_id).await?;
+        if self.caching {
+            self.user_id_domain_id_cache.write().await.remove(user_id);
+        }
+        Ok(())
+    }
+
+    /// Get single user.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn get_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError> {
+        let user = self.backend_driver.get_user(state, user_id).await?;
+        if self.caching
+            && let Some(user) = &user
+        {
+            self.user_id_domain_id_cache
+                .write()
+                .await
+                .insert(user_id.to_string(), user.domain_id.clone());
+        }
+        Ok(user)
+    }
+
+    /// Get `domain_id` of a user.
+    ///
+    /// When the caching is enabled check for the cached value there. When no
+    /// data is present for the key - invoke the backend driver and place
+    /// the new value into the cache. Other operations (`get_user`,
+    /// `delete_user`) update the cache with `delete_user` purging the value
+    /// from the cache.
+    async fn get_user_domain_id<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<String>, IdentityProviderError> {
+        if self.caching {
+            if let Some(domain_id) = self.user_id_domain_id_cache.read().await.get(user_id) {
+                return Ok(Some(domain_id.clone()));
+            } else {
+                let domain_id = self
+                    .backend_driver
+                    .get_user_domain_id(state, user_id)
+                    .await?;
+                if let Some(did) = &domain_id {
+                    self.user_id_domain_id_cache
+                        .write()
+                        .await
+                        .insert(user_id.to_string(), did.clone());
+                }
+                return Ok(domain_id);
+            }
+        } else {
+            Ok(self
+                .backend_driver
+                .get_user_domain_id(state, user_id)
+                .await?)
+        }
+    }
+
+    /// Find federated user by `idp_id` and `unique_id`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn find_federated_user<'a>(
+        &self,
+        state: &ServiceState,
+        idp_id: &'a str,
+        unique_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError> {
+        self.backend_driver
+            .find_federated_user(state, idp_id, unique_id)
+            .await
+    }
+
+    /// List users.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn list_users(
+        &self,
+        state: &ServiceState,
+        params: &UserListParameters,
+    ) -> Result<impl IntoIterator<Item = UserResponse>, IdentityProviderError> {
+        self.backend_driver.list_users(state, params).await
+    }
+
+    /// List groups.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn list_groups(
+        &self,
+        state: &ServiceState,
+        params: &GroupListParameters,
+    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError> {
+        self.backend_driver.list_groups(state, params).await
+    }
+
+    /// Get single group.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn get_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<Option<Group>, IdentityProviderError> {
+        self.backend_driver.get_group(state, group_id).await
+    }
+
+    /// Create group.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn create_group(
+        &self,
+        state: &ServiceState,
+        group: GroupCreate,
+    ) -> Result<Group, IdentityProviderError> {
+        let mut res = group;
+        if res.id.is_none() {
+            res.id = Some(Uuid::new_v4().simple().to_string());
+        }
+        self.backend_driver.create_group(state, res).await
+    }
+
+    /// List groups a user is a member of.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn list_groups_of_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError> {
+        self.backend_driver
+            .list_groups_of_user(state, user_id)
             .await
     }
 
@@ -366,5 +435,123 @@ impl IdentityApi for IdentityProvider {
         self.backend_driver
             .set_user_groups_expiring(state, user_id, group_ids, idp_id, last_verified)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::backend::MockIdentityBackend;
+    use super::types::user::UserCreateBuilder;
+    use super::*;
+    use crate::tests::get_state_mock;
+
+    #[tokio::test]
+    async fn test_create_user() {
+        let state = get_state_mock();
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_create_user()
+            .returning(|_, _| Ok(UserResponse::default()));
+        let provider = IdentityProvider::from_driver(backend);
+
+        assert_eq!(
+            provider
+                .create_user(
+                    &state,
+                    UserCreateBuilder::default()
+                        .name("uname")
+                        .domain_id("did")
+                        .build()
+                        .unwrap()
+                )
+                .await
+                .unwrap(),
+            UserResponse::default()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_user() {
+        let state = get_state_mock();
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user()
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(Some(UserResponse::default())));
+        let provider = IdentityProvider::from_driver(backend);
+
+        assert_eq!(
+            provider
+                .get_user(&state, "uid")
+                .await
+                .unwrap()
+                .expect("user should be there"),
+            UserResponse::default()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_user_domain_id() {
+        let state = get_state_mock();
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user_domain_id()
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .times(2) // only 2 times
+            .returning(|_, _| Ok(Some("did".into())));
+        backend
+            .expect_get_user_domain_id()
+            .withf(|_, uid: &'_ str| uid == "missing")
+            .returning(|_, _| Ok(None));
+        let mut provider = IdentityProvider::from_driver(backend);
+        provider.caching = true;
+
+        assert_eq!(
+            provider
+                .get_user_domain_id(&state, "uid")
+                .await
+                .unwrap()
+                .expect("domain_id should be there"),
+            "did"
+        );
+        assert_eq!(
+            provider
+                .get_user_domain_id(&state, "uid")
+                .await
+                .unwrap()
+                .expect("domain_id should be there"),
+            "did",
+            "second time data extracted from cache"
+        );
+        assert!(
+            provider
+                .get_user_domain_id(&state, "missing")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        provider.caching = false;
+        assert_eq!(
+            provider
+                .get_user_domain_id(&state, "uid")
+                .await
+                .unwrap()
+                .expect("domain_id should be there"),
+            "did",
+            "third time backend is again triggered causing total of 2 invocations"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_user() {
+        let state = get_state_mock();
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_delete_user()
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(()));
+        let provider = IdentityProvider::from_driver(backend);
+
+        assert!(provider.delete_user(&state, "uid").await.is_ok());
     }
 }

--- a/src/identity/types/provider_api.rs
+++ b/src/identity/types/provider_api.rs
@@ -23,74 +23,6 @@ use crate::keystone::ServiceState;
 
 #[async_trait]
 pub trait IdentityApi: Send + Sync {
-    async fn authenticate_by_password(
-        &self,
-        state: &ServiceState,
-        auth: &UserPasswordAuthRequest,
-    ) -> Result<AuthenticatedInfo, IdentityProviderError>;
-
-    async fn list_users(
-        &self,
-        state: &ServiceState,
-        params: &UserListParameters,
-    ) -> Result<impl IntoIterator<Item = UserResponse>, IdentityProviderError>;
-
-    async fn get_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<Option<UserResponse>, IdentityProviderError>;
-
-    async fn find_federated_user<'a>(
-        &self,
-        state: &ServiceState,
-        idp_id: &'a str,
-        unique_id: &'a str,
-    ) -> Result<Option<UserResponse>, IdentityProviderError>;
-
-    async fn create_user(
-        &self,
-        state: &ServiceState,
-        user: UserCreate,
-    ) -> Result<UserResponse, IdentityProviderError>;
-
-    async fn delete_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<(), IdentityProviderError>;
-
-    async fn list_groups(
-        &self,
-        state: &ServiceState,
-        params: &GroupListParameters,
-    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError>;
-
-    async fn get_group<'a>(
-        &self,
-        state: &ServiceState,
-        group_id: &'a str,
-    ) -> Result<Option<Group>, IdentityProviderError>;
-
-    async fn create_group(
-        &self,
-        state: &ServiceState,
-        group: GroupCreate,
-    ) -> Result<Group, IdentityProviderError>;
-
-    async fn delete_group<'a>(
-        &self,
-        state: &ServiceState,
-        group_id: &'a str,
-    ) -> Result<(), IdentityProviderError>;
-
-    /// List groups the user is a member of.
-    async fn list_groups_of_user<'a>(
-        &self,
-        state: &ServiceState,
-        user_id: &'a str,
-    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError>;
-
     /// Add the user to the single group.
     async fn add_user_to_group<'a>(
         &self,
@@ -122,6 +54,81 @@ pub trait IdentityApi: Send + Sync {
         memberships: Vec<(&'a str, &'a str)>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
+
+    async fn authenticate_by_password(
+        &self,
+        state: &ServiceState,
+        auth: &UserPasswordAuthRequest,
+    ) -> Result<AuthenticatedInfo, IdentityProviderError>;
+
+    async fn create_group(
+        &self,
+        state: &ServiceState,
+        group: GroupCreate,
+    ) -> Result<Group, IdentityProviderError>;
+
+    async fn create_user(
+        &self,
+        state: &ServiceState,
+        user: UserCreate,
+    ) -> Result<UserResponse, IdentityProviderError>;
+
+    async fn delete_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<(), IdentityProviderError>;
+
+    async fn get_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<Option<Group>, IdentityProviderError>;
+
+    async fn get_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError>;
+
+    /// Get single user by ID.
+    async fn get_user_domain_id<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<String>, IdentityProviderError>;
+
+    async fn find_federated_user<'a>(
+        &self,
+        state: &ServiceState,
+        idp_id: &'a str,
+        unique_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError>;
+
+    async fn list_groups(
+        &self,
+        state: &ServiceState,
+        params: &GroupListParameters,
+    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError>;
+
+    async fn list_users(
+        &self,
+        state: &ServiceState,
+        params: &UserListParameters,
+    ) -> Result<impl IntoIterator<Item = UserResponse>, IdentityProviderError>;
+
+    async fn delete_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<(), IdentityProviderError>;
+
+    /// List groups the user is a member of.
+    async fn list_groups_of_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<impl IntoIterator<Item = Group>, IdentityProviderError>;
 
     /// Remove the user from the single group.
     async fn remove_user_from_group<'a>(

--- a/src/identity/types/user.rs
+++ b/src/identity/types/user.rs
@@ -46,9 +46,9 @@ pub struct UserResponse {
     #[builder(default)]
     pub extra: Option<Value>,
     /// List of federated objects associated with a user. Each object in the
-    /// list contains the idp_id and protocols. protocols is a list of objects,
-    /// each of which contains protocol_id and unique_id of the protocol and
-    /// user respectively.
+    /// list contains the `idp_id` and `protocols`. `protocols` is a list of
+    /// objects, each of which contains `protocol_id` and `unique_id` of the
+    /// protocol and user respectively.
     #[builder(default)]
     #[validate(nested)]
     pub federated: Option<Vec<Federation>>,
@@ -67,44 +67,55 @@ pub struct UserResponse {
     pub password_expires_at: Option<DateTime<Utc>>,
 }
 
+/// User creation data.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct UserCreate {
+    /// The ID of the default project for the user.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 64))]
+    pub default_project_id: Option<String>,
+
+    /// The ID of the domain.
+    #[validate(length(min = 1, max = 64))]
+    pub domain_id: String,
+
+    /// If the user is enabled, this value is true. If the user is disabled,
+    /// this value is false.
+    #[builder(default)]
+    pub enabled: Option<bool>,
+
+    /// Additional user properties.
+    #[builder(default)]
+    pub extra: Option<Value>,
+
+    /// List of federated objects associated with a user. Each object in the
+    /// list contains the `idp_id` and `protocols`. `protocols` is a list of
+    /// objects, each of which contains `protocol_id` and `unique_id` of the
+    /// protocol and user respectively.
+    #[builder(default)]
+    #[validate(nested)]
+    pub federated: Option<Vec<Federation>>,
+
+    /// The ID of the user. When unset a new UUID would be assigned.
     #[builder(default)]
     #[validate(length(min = 1, max = 64))]
     pub id: Option<String>,
+
     /// The user name. Must be unique within the owning domain.
-    #[validate(length(max = 255))]
+    #[validate(length(min = 1, max = 255))]
     pub name: String,
-    /// The ID of the domain.
-    #[validate(length(max = 64))]
-    pub domain_id: String,
-    /// If the user is enabled, this value is true. If the user is disabled,
-    /// this value is false.
-    pub enabled: Option<bool>,
-    /// The ID of the default project for the user.
-    #[builder(default)]
-    #[validate(length(max = 64))]
-    pub default_project_id: Option<String>,
-    /// User password
-    #[builder(default)]
-    #[validate(length(max = 72))]
-    pub password: Option<String>,
-    /// Additional user properties
-    #[builder(default)]
-    pub extra: Option<Value>,
+
     /// The resource options for the user.
     #[builder(default)]
     #[validate(nested)]
     pub options: Option<UserOptions>,
-    /// List of federated objects associated with a user. Each object in the
-    /// list contains the idp_id and protocols. protocols is a list of objects,
-    /// each of which contains protocol_id and unique_id of the protocol and
-    /// user respectively.
+
+    /// User password.
     #[builder(default)]
-    #[validate(nested)]
-    pub federated: Option<Vec<Federation>>,
+    #[validate(length(max = 72))]
+    pub password: Option<String>,
 }
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
@@ -143,6 +154,7 @@ pub struct UserUpdate {
     pub password: Option<String>,
 }
 
+/// User options.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]

--- a/src/identity_mapping/mod.rs
+++ b/src/identity_mapping/mod.rs
@@ -37,7 +37,6 @@ use types::*;
 pub use mock::MockIdentityMappingProvider;
 pub use types::IdentityMappingApi;
 
-#[derive(Clone)]
 pub struct IdentityMappingProvider {
     /// Backend driver.
     backend_driver: Arc<dyn IdentityMappingBackend>,

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -50,7 +50,6 @@ use crate::resource::types::{Domain, Project};
 pub use mock::MockResourceProvider;
 pub use types::ResourceApi;
 
-#[derive(Clone)]
 pub struct ResourceProvider {
     backend_driver: Arc<dyn ResourceBackend>,
 }

--- a/src/revoke/mod.rs
+++ b/src/revoke/mod.rs
@@ -56,7 +56,6 @@ pub use mock::MockRevokeProvider;
 pub use types::*;
 
 /// Revoke provider.
-#[derive(Clone)]
 pub struct RevokeProvider {
     /// Backend driver.
     backend_driver: Arc<dyn RevokeBackend>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,5 +12,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Test related functionality
+use sea_orm::DatabaseConnection;
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::keystone::Service;
+use crate::policy::MockPolicyFactory;
+use crate::provider::Provider;
+
 pub(crate) mod api;
 pub(crate) mod token;
+
+pub fn get_state_mock() -> Arc<Service> {
+    Arc::new(
+        Service::new(
+            Config::default(),
+            DatabaseConnection::Disconnected,
+            Provider::mocked_builder().build().unwrap(),
+            MockPolicyFactory::default(),
+        )
+        .unwrap(),
+    )
+}

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -59,7 +59,6 @@ pub use crate::token::types::*;
 #[cfg(test)]
 pub use mock::MockTokenProvider;
 
-#[derive(Clone)]
 pub struct TokenProvider {
     config: Config,
     backend_driver: Arc<dyn TokenBackend>,

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -76,7 +76,6 @@ pub use mock::MockTrustProvider;
 pub use types::*;
 
 /// Trust provider.
-#[derive(Clone)]
 pub struct TrustProvider {
     /// Backend driver.
     backend_driver: Arc<dyn TrustBackend>,


### PR DESCRIPTION
There are lot of cases where it is necessary to determine the
`domain_id` by the `user_id`. Fetching the whole user is relatively
expensive due to the multiple table joins while the attribute itself is
present already on the main table entry. Implement a method that only
returns the `domain_id` attribute by the `user_id`. Since this data can
never change (unless somebody mess directly in the database) caching can
be implemented to further improve the performance (when
`conf.identity.caching` is true).
