### PR TITLE
refactor: Use `Url` as a type for config public_endpoint

### DIFF
--- a/src/api/common.rs
+++ b/src/api/common.rs
@@ -137,13 +137,11 @@ where
             if (data.len() as u64) >= *limit
                 && let Some(last_id) = data.last().map(|x| x.get_id())
             {
-                let mut url = Url::parse(
-                    config
-                        .default
-                        .public_endpoint
-                        .as_ref()
-                        .map_or("http://localhost", |v| v),
-                )?;
+                let mut url = if let Some(pe) = &config.default.public_endpoint {
+                    pe.clone()
+                } else {
+                    Url::parse("http://localhost")?
+                };
                 url.set_path(collection_url);
                 let mut new_query = query.clone();
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -90,6 +90,7 @@ async fn version(
         .default
         .public_endpoint
         .clone()
+        .map(|x| x.to_string())
         .or_else(|| {
             headers
                 .get(header::HOST)

--- a/src/api/v3/mod.rs
+++ b/src/api/v3/mod.rs
@@ -75,6 +75,7 @@ async fn version(
         .default
         .public_endpoint
         .clone()
+        .map(|x| x.to_string())
         .or_else(|| {
             headers
                 .get(header::HOST)

--- a/src/api/v4/mod.rs
+++ b/src/api/v4/mod.rs
@@ -78,6 +78,7 @@ async fn version(
         .default
         .public_endpoint
         .clone()
+        .map(|x| x.to_string())
         .or_else(|| {
             headers
                 .get(header::HOST)

--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use serde::Deserialize;
+use url::Url;
 
 /// Default configuration section.
 #[derive(Debug, Default, Deserialize, Clone)]
@@ -19,5 +20,5 @@ pub struct DefaultSection {
     /// Debug logging.
     pub debug: Option<bool>,
     /// Public endpoint.
-    pub public_endpoint: Option<String>,
+    pub public_endpoint: Option<Url>,
 }


### PR DESCRIPTION
In order to skip repeated parsing of the url set in the config as a
public_endpoint change it's type in the config so that it is only parsed
once during the config load.
