### PR TITLE
feat: Add `create_revocation_event` method

### DIFF
--- a/src/api/common.rs
+++ b/src/api/common.rs
@@ -261,12 +261,12 @@ mod tests {
         }
     }
 
-    /// Fake resource for pagination testing
+    /// Fake resource for pagination testing.
     struct FakeResource {
         pub id: String,
     }
 
-    /// Fake query params for pagination testing
+    /// Fake query params for pagination testing.
     #[derive(Clone, Default, Serialize)]
     struct FakeQueryParams {
         pub marker: Option<String>,

--- a/src/revoke/backend.rs
+++ b/src/revoke/backend.rs
@@ -16,7 +16,7 @@
 use async_trait::async_trait;
 
 use crate::keystone::ServiceState;
-use crate::revoke::RevokeProviderError;
+use crate::revoke::{RevokeProviderError, types::*};
 use crate::token::types::Token;
 
 pub mod error;
@@ -28,6 +28,13 @@ pub mod sql;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait RevokeBackend: Send + Sync {
+    /// Create revocation event.
+    async fn create_revocation_event(
+        &self,
+        state: &ServiceState,
+        event: RevocationEventCreate,
+    ) -> Result<RevocationEvent, RevokeProviderError>;
+
     /// Check token revocation.
     ///
     /// Check whether there are existing revocation records that invalidate the

--- a/src/revoke/backend/sql.rs
+++ b/src/revoke/backend/sql.rs
@@ -52,6 +52,15 @@ impl TryFrom<db_revocation_event::Model> for RevocationEvent {
 
 #[async_trait]
 impl RevokeBackend for SqlBackend {
+    /// Create revocation event.
+    async fn create_revocation_event(
+        &self,
+        state: &ServiceState,
+        event: RevocationEventCreate,
+    ) -> Result<RevocationEvent, RevokeProviderError> {
+        Ok(create::create(&state.db, event).await?)
+    }
+
     /// Check the token for being revoked.
     ///
     /// List not expired revocation records that invalidate the token and

--- a/src/revoke/mock.rs
+++ b/src/revoke/mock.rs
@@ -18,8 +18,7 @@ use mockall::mock;
 
 use crate::config::Config;
 use crate::plugin_manager::PluginManager;
-use crate::revoke::RevokeApi;
-use crate::revoke::error::RevokeProviderError;
+use crate::revoke::{RevokeApi, RevokeProviderError, types::*};
 use crate::token::types::Token;
 
 use crate::keystone::ServiceState;
@@ -32,6 +31,12 @@ mock! {
 
     #[async_trait]
     impl RevokeApi for RevokeProvider {
+        async fn create_revocation_event(
+            &self,
+            state: &ServiceState,
+            event: RevocationEventCreate
+        ) -> Result<RevocationEvent, RevokeProviderError>;
+
         async fn is_token_revoked(
             &self,
             state: &ServiceState,

--- a/src/revoke/types/provider_api.rs
+++ b/src/revoke/types/provider_api.rs
@@ -17,12 +17,19 @@
 use async_trait::async_trait;
 
 use crate::keystone::ServiceState;
-use crate::revoke::RevokeProviderError;
+use crate::revoke::{RevokeProviderError, types::*};
 use crate::token::types::Token;
 
 /// Revocation Provider interface.
 #[async_trait]
 pub trait RevokeApi: Send + Sync {
+    /// Create revocation event.
+    async fn create_revocation_event(
+        &self,
+        state: &ServiceState,
+        event: RevocationEventCreate,
+    ) -> Result<RevocationEvent, RevokeProviderError>;
+
     /// Check whether the token has been revoked of not.
     ///
     /// Checks revocation events matching the token parameters and return


### PR DESCRIPTION
In order to be able to revoke tokens by specific individual parameters
(i.e. when individual grant has been revoked) a new provider API is
being introduced.

Fix: #529
