### PR TITLE
fix: Prevent endless extending token

### DIFF
--- a/crates/keystone/src/auth/mod.rs
+++ b/crates/keystone/src/auth/mod.rs
@@ -21,6 +21,7 @@
 //! same is valid for the authorization validation (project/domain must exist
 //! and be enabled).
 
+use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -76,8 +77,29 @@ pub struct AuthenticatedInfo {
     #[builder(default)]
     pub application_credential: Option<ApplicationCredential>,
 
-    /// User id.
-    pub user_id: String,
+    /// Audit IDs.
+    #[builder(default)]
+    pub audit_ids: Vec<String>,
+
+    /// Authentication expiration.
+    #[builder(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// Federated IDP id.
+    #[builder(default)]
+    pub idp_id: Option<String>,
+
+    /// Authentication methods.
+    #[builder(default)]
+    pub methods: Vec<String>,
+
+    /// Federated protocol id.
+    #[builder(default)]
+    pub protocol_id: Option<String>,
+
+    /// Token restriction.
+    #[builder(default)]
+    pub token_restriction_id: Option<String>,
 
     /// Resolved user object.
     #[builder(default)]
@@ -91,25 +113,8 @@ pub struct AuthenticatedInfo {
     #[builder(default)]
     pub user_groups: Vec<Group>,
 
-    /// Authentication methods.
-    #[builder(default)]
-    pub methods: Vec<String>,
-
-    /// Audit IDs.
-    #[builder(default)]
-    pub audit_ids: Vec<String>,
-
-    /// Federated IDP id.
-    #[builder(default)]
-    pub idp_id: Option<String>,
-
-    /// Federated protocol id.
-    #[builder(default)]
-    pub protocol_id: Option<String>,
-
-    /// Token restriction.
-    #[builder(default)]
-    pub token_restriction_id: Option<String>,
+    /// User id.
+    pub user_id: String,
 }
 
 impl AuthenticatedInfo {

--- a/crates/keystone/src/token/types/restricted.rs
+++ b/crates/keystone/src/token/types/restricted.rs
@@ -98,6 +98,7 @@ impl From<RestrictedPayload> for Token {
 /// Token restriction information.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(into, strip_option))]
 pub struct TokenRestriction {
     /// Whether the restriction allows to rescope the token.
     pub allow_rescope: bool,
@@ -108,12 +109,15 @@ pub struct TokenRestriction {
     /// Domain Id the token restriction belongs to.
     pub domain_id: String,
     /// Optional project ID to be used with this restriction.
+    #[builder(default)]
     pub project_id: Option<String>,
     /// Roles bound to the restriction.
     pub role_ids: Vec<String>,
     /// Optional list of full Role information.
+    #[builder(default)]
     pub roles: Option<Vec<crate::assignment::types::Role>>,
     /// User id.
+    #[builder(default)]
     pub user_id: Option<String>,
 }
 


### PR DESCRIPTION
When user authenticates with a token new token expiration must be
limited to the one of the original authentication.

Closes: #539
