### PR TITLE
refactor: Rework http client pool

### DIFF
--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -12,5 +12,44 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Common functionality
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use tokio::sync::RwLock;
+
 pub mod password_hashing;
 pub mod types;
+
+/// HTTP Client pool trait.
+#[async_trait]
+pub trait HttpClientProvider: Send + Sync {
+    /// Get established [Client] by the name.
+    async fn get_client(&self, name: &str) -> Option<Arc<Client>>;
+    /// Pub established [Client] into the connection pool.
+    async fn put_client(&self, name: &str, client: Arc<Client>);
+}
+
+/// Http client pool.
+///
+/// NOTE: Simply placing the RwLock<HashMap<String, Arc<Client>>> into the providers immediately
+/// explodes the compilation time. To deal with it is moved out into a separate structure making it
+/// at the same time reusable.
+#[derive(Default)]
+pub struct HttpClientPool {
+    pub inner: RwLock<HashMap<String, Arc<Client>>>,
+}
+
+#[async_trait]
+impl HttpClientProvider for HttpClientPool {
+    async fn get_client(&self, name: &str) -> Option<Arc<Client>> {
+        let read_guard = self.inner.read().await;
+        read_guard.get(name).cloned()
+    }
+
+    async fn put_client(&self, name: &str, client: Arc<Client>) {
+        let mut write_guard = self.inner.write().await;
+        write_guard.insert(name.to_string(), client);
+    }
+}

--- a/crates/core/src/k8s_auth/auth.rs
+++ b/crates/core/src/k8s_auth/auth.rs
@@ -56,11 +56,8 @@ impl K8sAuthService {
         ca_path: Option<PathBuf>,
     ) -> Result<Arc<Client>, K8sAuthProviderError> {
         // Check if we already have a pooled client
-        {
-            let read_guard = self.http_clients.read().await;
-            if let Some(client) = read_guard.get(&instance.id) {
-                return Ok(Arc::clone(client));
-            }
+        if let Some(client) = self.http_client_pool.get_client(&instance.id).await {
+            return Ok(client);
         }
 
         // Create a new one
@@ -88,9 +85,10 @@ impl K8sAuthService {
         // Build the client
         let shared_client = Arc::new(client_builder.build()?);
 
-        // 3. Store it for future use
-        let mut write_guard = self.http_clients.write().await;
-        write_guard.insert(instance.id.clone(), Arc::clone(&shared_client));
+        // Store it for future use
+        self.http_client_pool
+            .put_client(&instance.id, Arc::clone(&shared_client))
+            .await;
 
         Ok(shared_client)
     }
@@ -307,7 +305,6 @@ impl K8sAuthService {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::io::Write;
     use std::sync::Arc;
 
@@ -316,10 +313,10 @@ mod tests {
     use httpmock::{Mock, MockServer};
     use jsonwebtoken::{EncodingKey, Header, encode};
     use tempfile::NamedTempFile;
-    use tokio::sync::RwLock;
 
     use super::super::backend::MockK8sAuthBackend;
     use super::*;
+    use crate::common::HttpClientPool;
     use crate::identity::{MockIdentityProvider, types::*};
     use crate::keystone::Service;
     use crate::provider::Provider;
@@ -423,7 +420,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
 
         let provider = K8sAuthService {
             backend_driver: Arc::new(backend),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         let token = SecretString::from(encode(
@@ -447,7 +444,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_get_or_create_client_with_ca() -> Result<()> {
         let srv = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let instance = K8sAuthInstance {
             ca_cert: Some(CA_CERT.into()),
@@ -459,10 +456,13 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
             name: Some("foo".into()),
         };
         srv.get_or_create_client(&instance, None).await?;
-        {
-            let read_guard = srv.http_clients.read().await;
-            assert!(read_guard.contains_key(&instance.id));
-        }
+        //  Ensure the connection is present in the pool
+        assert!(
+            srv.http_client_pool
+                .get_client(&instance.id)
+                .await
+                .is_some()
+        );
         // Repeat the get, now it should be returned from the cache
         srv.get_or_create_client(&instance, None).await?;
 
@@ -484,7 +484,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_get_or_create_client_k8s_ca() -> Result<()> {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let instance = K8sAuthInstance {
             ca_cert: None,
@@ -510,7 +510,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_get_or_create_client_error_no_ca() -> Result<()> {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let instance = K8sAuthInstance {
             ca_cert: None,
@@ -534,7 +534,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_get_or_create_client_disable_local_ca_jwt() -> Result<()> {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let instance = K8sAuthInstance {
             ca_cert: None,
@@ -553,7 +553,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_query_k8s_token_review_aud_mismatch() -> Result<()> {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let instance = K8sAuthInstance {
             ca_cert: None,
@@ -601,7 +601,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_query_k8s_token_review_expired() -> Result<()> {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let instance = K8sAuthInstance {
             ca_cert: None,
@@ -649,7 +649,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     async fn test_query_k8s_token_review() -> Result<()> {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
         let mock_srv = MockServer::start_async().await;
         let instance = K8sAuthInstance {
@@ -756,7 +756,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
     fn test_check_k8s_token_review_response() {
         let provider = K8sAuthService {
             backend_driver: Arc::new(MockK8sAuthBackend::default()),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         let role = K8sAuthRole {
@@ -863,7 +863,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
             .returning(|_, _| Ok(None));
         let provider = K8sAuthService {
             backend_driver: Arc::new(backend),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         if let Err(K8sAuthProviderError::AuthInstanceNotFound(x)) = provider
@@ -912,7 +912,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
 
         let provider = K8sAuthService {
             backend_driver: Arc::new(backend),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         if let Err(K8sAuthProviderError::RoleNotFound(x)) = provider
@@ -1007,7 +1007,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
 
         let provider = K8sAuthService {
             backend_driver: Arc::new(backend),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         // verify disabled configuration is checked

--- a/crates/core/src/k8s_auth/service.rs
+++ b/crates/core/src/k8s_auth/service.rs
@@ -13,18 +13,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Kubernetes authentication.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use reqwest::Client;
-use tokio::sync::RwLock;
 
+use crate::auth::AuthenticatedInfo;
+use crate::common::{HttpClientPool, HttpClientProvider};
+use crate::config::Config;
 use crate::k8s_auth::{K8sAuthProviderError, backend::K8sAuthBackend, types::*};
 use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 use crate::token::types::TokenRestriction;
-use crate::{auth::AuthenticatedInfo, config::Config};
 
 /// K8s Auth provider.
 pub struct K8sAuthService {
@@ -32,7 +31,7 @@ pub struct K8sAuthService {
     pub(super) backend_driver: Arc<dyn K8sAuthBackend>,
 
     /// Reqwest client.
-    pub(super) http_clients: RwLock<HashMap<String, Arc<Client>>>,
+    pub(super) http_client_pool: Box<dyn HttpClientProvider>,
 }
 
 impl K8sAuthService {
@@ -45,7 +44,7 @@ impl K8sAuthService {
             .clone();
         Ok(Self {
             backend_driver,
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         })
     }
 }
@@ -191,7 +190,7 @@ pub(crate) mod tests {
             .returning(|_, _| Ok(K8sAuthInstance::default()));
         let provider = K8sAuthService {
             backend_driver: Arc::new(backend),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         assert!(
@@ -222,7 +221,7 @@ pub(crate) mod tests {
             .returning(|_, _| Ok(K8sAuthRole::default()));
         let provider = K8sAuthService {
             backend_driver: Arc::new(backend),
-            http_clients: RwLock::new(HashMap::new()),
+            http_client_pool: Box::new(HttpClientPool::default()),
         };
 
         assert!(

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -45,10 +45,9 @@ use crate::identity_mapping::IdentityMappingApi;
 use crate::identity_mapping::IdentityMappingProvider;
 #[cfg(any(test, feature = "mock"))]
 use crate::identity_mapping::MockIdentityMappingProvider;
-use crate::k8s_auth::K8sAuthApi;
-use crate::k8s_auth::K8sAuthProvider;
 #[cfg(any(test, feature = "mock"))]
 use crate::k8s_auth::MockK8sAuthProvider;
+use crate::k8s_auth::{K8sAuthApi, K8sAuthProvider};
 use crate::plugin_manager::PluginManagerApi;
 #[cfg(any(test, feature = "mock"))]
 use crate::resource::MockResourceProvider;


### PR DESCRIPTION
Using RwLock<HashMap<String, Arc<Client>>> inside the provider structure
makes compiler unhappy. Moving it into the separate structure allows
to half the crate compilation time.
