### PR TITLE
refactor: Introduce dynamic plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3390,6 +3399,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
@@ -3405,6 +3415,7 @@ name = "openstack-keystone-assignment-sql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
@@ -3418,6 +3429,7 @@ name = "openstack-keystone-catalog-sql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3453,6 +3465,7 @@ dependencies = [
  "derive_builder",
  "eyre",
  "httpmock",
+ "inventory",
  "jsonwebtoken",
  "mockall",
  "openstack-keystone-api-types",
@@ -3525,6 +3538,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_builder",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3541,6 +3555,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_builder",
+ "inventory",
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
@@ -3559,6 +3574,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3571,6 +3587,7 @@ name = "openstack-keystone-k8s-auth-sql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3584,6 +3601,7 @@ name = "openstack-keystone-resource-sql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3599,6 +3617,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3612,6 +3631,7 @@ name = "openstack-keystone-role-sql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3654,6 +3674,7 @@ name = "openstack-keystone-token-restriction-sql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -3667,6 +3688,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "sea-orm",
@@ -6029,21 +6051,14 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "eyre",
+ "inventory",
  "itertools 0.14.0",
  "openstack-keystone",
- "openstack-keystone-appcred-sql",
- "openstack-keystone-assignment-sql",
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
- "openstack-keystone-federation-sql",
  "openstack-keystone-identity-sql",
- "openstack-keystone-k8s-auth-sql",
- "openstack-keystone-resource-sql",
- "openstack-keystone-revoke-sql",
- "openstack-keystone-role-sql",
  "openstack-keystone-token-fernet",
- "openstack-keystone-token-restriction-sql",
  "openstack-keystone-trust-sql",
  "sea-orm",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ http-body-util = "0.1"
 http = { version = "1.4" }
 hyper = { version = "1.8" }
 hyper-util = { version = "0.1" }
+inventory = { version = "0.3" }
 itertools = { version = "0.14" }
 mockall = { version = "0.14" }
 mockall_double = { version = "0.3" }

--- a/crates/appcred-sql/Cargo.toml
+++ b/crates/appcred-sql/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
+inventory.workspace = true
 openstack-keystone-config = { version = "0.1", path = "../config" }
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }

--- a/crates/appcred-sql/src/lib.rs
+++ b/crates/appcred-sql/src/lib.rs
@@ -14,11 +14,15 @@
 //! # OpenStack Keystone Application Credential SQL driver
 
 use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::application_credential::{
     ApplicationCredentialProviderError, backend::ApplicationCredentialBackend,
 };
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::application_credential::*;
 
 mod application_credential;
@@ -28,6 +32,12 @@ pub mod entity;
 /// interface.
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl ApplicationCredentialBackend for SqlBackend {
@@ -56,5 +66,35 @@ impl ApplicationCredentialBackend for SqlBackend {
         params: &ApplicationCredentialListParameters,
     ) -> Result<Vec<ApplicationCredential>, ApplicationCredentialProviderError> {
         Ok(application_credential::list(&state.db, params).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::AccessRule).await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::ApplicationCredential,
+        )
+        .await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::ApplicationCredentialRole,
+        )
+        .await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::ApplicationCredentialAccessRule,
+        )
+        .await?;
+        Ok(())
     }
 }

--- a/crates/assignment-sql/Cargo.toml
+++ b/crates/assignment-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-config = { version = "0.1", path = "../config" }
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }

--- a/crates/assignment-sql/src/entity/assignment.rs
+++ b/crates/assignment-sql/src/entity/assignment.rs
@@ -22,11 +22,23 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub r#type: Type,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub actor_id: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub target_id: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub role_id: String,
     #[sea_orm(primary_key, auto_increment = false)]
     pub inherited: bool,

--- a/crates/assignment-sql/src/entity/system_assignment.rs
+++ b/crates/assignment-sql/src/entity/system_assignment.rs
@@ -21,11 +21,23 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub r#type: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub actor_id: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub target_id: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub role_id: String,
     #[sea_orm(primary_key, auto_increment = false)]
     pub inherited: bool,
@@ -33,11 +45,5 @@ pub struct Model {
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
-
-//impl Related<super::role::Entity> for Entity {
-//    fn to() -> RelationDef {
-//        Relation::Role.def()
-//    }
-//}
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/crates/assignment-sql/src/lib.rs
+++ b/crates/assignment-sql/src/lib.rs
@@ -13,14 +13,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Assignment driver to the OpenStack Keystone for the SQL database.
 
-use async_trait::async_trait;
 use std::collections::{BTreeMap, HashSet};
 
+use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
+
 use openstack_keystone_core::assignment::{AssignmentProviderError, backend::AssignmentBackend};
+use openstack_keystone_core::db::create_table;
+use openstack_keystone_core::error::DatabaseError;
 use openstack_keystone_core::identity::IdentityApi;
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::resource::ResourceApi;
 use openstack_keystone_core::role::RoleApi;
+use openstack_keystone_core::{SqlDriver, SqlDriverRegistration};
 use openstack_keystone_core_types::assignment::*;
 use openstack_keystone_core_types::role::*;
 
@@ -29,6 +34,12 @@ pub mod entity;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 impl SqlBackend {
     /// List role assignments for multiple actors/targets.
@@ -79,6 +90,19 @@ impl SqlBackend {
         }
 
         Ok(result_map.into_iter().collect())
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::Assignment).await?;
+        create_table(connection, schema, crate::entity::prelude::SystemAssignment).await?;
+        Ok(())
     }
 }
 

--- a/crates/catalog-sql/Cargo.toml
+++ b/crates/catalog-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/catalog-sql/src/lib.rs
+++ b/crates/catalog-sql/src/lib.rs
@@ -14,14 +14,17 @@
 //! # OpenStack Keystone SQL driver for the catalog provider
 
 use async_trait::async_trait;
-use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::catalog::CatalogProviderError;
 use openstack_keystone_core::catalog::backend::CatalogBackend;
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::catalog::*;
 
 use crate::entity::{
@@ -36,6 +39,12 @@ mod service;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl CatalogBackend for SqlBackend {
@@ -112,6 +121,28 @@ async fn get_catalog(
         res.push((service, endpoints?));
     }
     Ok(res)
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::Region).await?;
+        create_table(connection, schema, crate::entity::prelude::Service).await?;
+        create_table(connection, schema, crate::entity::prelude::Endpoint).await?;
+        create_table(connection, schema, crate::entity::prelude::EndpointGroup).await?;
+        create_table(connection, schema, crate::entity::prelude::ProjectEndpoint).await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::ProjectEndpointGroup,
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ bcrypt = { workspace = true, features = ["alloc"] }
 chrono = { workspace = true, default-features = false }
 derive_builder.workspace = true
 eyre.workspace = true
+inventory.workspace = true
 jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 openstack-keystone-api-types = { version = "0.1", path = "../api-types/", optional = true }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types/" }

--- a/crates/core/src/db.rs
+++ b/crates/core/src/db.rs
@@ -1,0 +1,57 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Internal tools for the database handling
+
+use sea_orm::{ConnectionTrait, EntityTrait, Schema, sea_query::IndexCreateStatement};
+
+use crate::error::{DatabaseError, DbContextExt};
+
+/// Create the table in the database with directly related types and indexes.
+pub async fn create_table<C, E>(conn: &C, schema: &Schema, entity: E) -> Result<(), DatabaseError>
+where
+    C: ConnectionTrait,
+    E: EntityTrait,
+{
+    // Create types before the table
+    for ttype in schema.create_enum_from_entity(entity) {
+        conn.execute(conn.get_database_backend().build(&ttype))
+            .await
+            .context("creating types")?;
+    }
+    // Create the table
+    conn.execute(
+        conn.get_database_backend()
+            .build(&schema.create_table_from_entity(entity)),
+    )
+    .await
+    .context("creating table")?;
+    // Create related indexes
+    for tidx in schema.create_index_from_entity(entity) {
+        conn.execute(conn.get_database_backend().build(&tidx))
+            .await
+            .context("creating table indexes")?;
+    }
+    Ok(())
+}
+
+/// Create the index.
+pub async fn create_index<C>(conn: &C, index: IndexCreateStatement) -> Result<(), DatabaseError>
+where
+    C: ConnectionTrait,
+{
+    conn.execute(conn.get_database_backend().build(&index))
+        .await
+        .context("creating the index")?;
+    Ok(())
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -71,6 +71,8 @@
 //! current objective is to retain the existing Keystone Python implementation
 //! as the trusted, mature baseline and incrementally build the “Keystone-NG”
 //! Rust service as the complement.
+use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
 
 #[cfg(feature = "api")]
 pub mod api;
@@ -79,6 +81,7 @@ pub mod assignment;
 pub mod auth;
 pub mod catalog;
 pub mod common;
+pub mod db;
 pub mod error;
 pub mod federation;
 pub mod identity;
@@ -96,3 +99,20 @@ pub mod trust;
 
 #[cfg(test)]
 pub mod tests;
+
+#[async_trait]
+pub trait SqlDriver: Send + Sync {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), error::DatabaseError>;
+}
+
+// This struct "wraps" the trait object so inventory can track it
+pub struct SqlDriverRegistration {
+    pub driver: &'static dyn SqlDriver,
+}
+
+// Essential: This creates the global registry for this specific struct
+inventory::collect!(SqlDriverRegistration);

--- a/crates/federation-sql/Cargo.toml
+++ b/crates/federation-sql/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, features = ["now"] }
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/federation-sql/src/lib.rs
+++ b/crates/federation-sql/src/lib.rs
@@ -14,8 +14,13 @@
 //! OpenStack Keystone SQL driver for the federation provider
 use async_trait::async_trait;
 
+use sea_orm::{DatabaseConnection, Schema};
+
 use openstack_keystone_core::federation::{FederationProviderError, backend::FederationBackend};
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::federation::*;
 
 mod auth_state;
@@ -25,6 +30,12 @@ mod mapping;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl FederationBackend for SqlBackend {
@@ -164,6 +175,39 @@ impl FederationBackend for SqlBackend {
         idp: MappingUpdate,
     ) -> Result<Mapping, FederationProviderError> {
         Ok(mapping::update(&state.db, id, idp).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::FederatedIdentityProvider,
+        )
+        .await?;
+        create_table(connection, schema, crate::entity::prelude::FederatedMapping).await?;
+        create_table(connection, schema, crate::entity::prelude::IdentityProvider).await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::FederationProtocol,
+        )
+        .await?;
+        create_table(connection, schema, crate::entity::prelude::IdpRemoteIds).await?;
+        create_table(connection, schema, crate::entity::prelude::Mapping).await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::FederatedAuthState,
+        )
+        .await?;
+        Ok(())
     }
 }
 

--- a/crates/identity-sql/Cargo.toml
+++ b/crates/identity-sql/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, features = ["now"] }
+inventory.workspace = true
 openstack-keystone-config = { version = "0.1", path = "../config" }
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }

--- a/crates/identity-sql/src/entity/expiring_user_group_membership.rs
+++ b/crates/identity-sql/src/entity/expiring_user_group_membership.rs
@@ -19,9 +19,17 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "expiring_user_group_membership")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub user_id: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub group_id: String,
     #[sea_orm(primary_key, auto_increment = false)]
     pub idp_id: String,

--- a/crates/identity-sql/src/entity/federated_user.rs
+++ b/crates/identity-sql/src/entity/federated_user.rs
@@ -21,6 +21,7 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub user_id: String,
     pub idp_id: String,
     pub protocol_id: String,

--- a/crates/identity-sql/src/entity/group.rs
+++ b/crates/identity-sql/src/entity/group.rs
@@ -19,9 +19,15 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "group")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub id: String,
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub domain_id: String,
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub name: String,
     #[sea_orm(column_type = "Text", nullable)]
     pub description: Option<String>,

--- a/crates/identity-sql/src/entity/local_user.rs
+++ b/crates/identity-sql/src/entity/local_user.rs
@@ -21,8 +21,11 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub user_id: String,
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub domain_id: String,
+    #[sea_orm(column_type = "String(StringLen::N(255))")]
     pub name: String,
     pub failed_auth_count: Option<i32>,
     pub failed_auth_at: Option<DateTime>,
@@ -36,7 +39,6 @@ pub enum Relation {
         belongs_to = "super::user::Entity",
         from = "(Column::UserId, Column::DomainId)",
         to = "(super::user::Column::Id, super::user::Column::DomainId)",
-        fk_name = "local_user_user_id_fkey",
         on_update = "Cascade",
         on_delete = "Cascade"
     )]

--- a/crates/identity-sql/src/entity/nonlocal_user.rs
+++ b/crates/identity-sql/src/entity/nonlocal_user.rs
@@ -35,7 +35,6 @@ pub enum Relation {
         belongs_to = "super::user::Entity",
         from = "(Column::UserId, Column::DomainId)",
         to = "(super::user::Column::Id, super::user::Column::DomainId)",
-        fk_name = "nonlocal_user_user_id_fkey",
         on_update = "Cascade",
         on_delete = "Cascade"
     )]

--- a/crates/identity-sql/src/entity/user.rs
+++ b/crates/identity-sql/src/entity/user.rs
@@ -30,8 +30,10 @@ pub struct Model {
     pub created_at: Option<DateTime>,
 
     #[cfg_attr(test, builder(default))]
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub default_project_id: Option<String>,
 
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
     pub domain_id: String,
 
     #[cfg_attr(test, builder(default))]
@@ -41,7 +43,11 @@ pub struct Model {
     #[cfg_attr(test, builder(default))]
     pub extra: Option<String>,
 
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub id: String,
 
     #[cfg_attr(test, builder(default))]

--- a/crates/identity-sql/src/entity/user_group_membership.rs
+++ b/crates/identity-sql/src/entity/user_group_membership.rs
@@ -19,9 +19,17 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "user_group_membership")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub user_id: String,
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub group_id: String,
 }
 

--- a/crates/identity-sql/src/entity/user_option.rs
+++ b/crates/identity-sql/src/entity/user_option.rs
@@ -19,7 +19,11 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "user_option")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
     pub user_id: String,
 
     #[sea_orm(primary_key, auto_increment = false)]

--- a/crates/identity-sql/src/lib.rs
+++ b/crates/identity-sql/src/lib.rs
@@ -16,11 +16,17 @@ use std::collections::HashSet;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use sea_orm::{DatabaseConnection, Schema, sea_query::Index};
 
 use openstack_keystone_core::auth::AuthenticatedInfo;
 use openstack_keystone_core::identity::IdentityProviderError;
 use openstack_keystone_core::identity::backend::IdentityBackend;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration,
+    db::{create_index, create_table},
+    error::DatabaseError,
+};
 use openstack_keystone_core_types::identity::*;
 
 mod authenticate;
@@ -37,6 +43,12 @@ mod user_option;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl IdentityBackend for SqlBackend {
@@ -320,6 +332,48 @@ impl IdentityBackend for SqlBackend {
             last_verified,
         )
         .await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::User).await?;
+        create_index(
+            connection,
+            Index::create()
+                .name("ixu_user_id_domain_id")
+                .table(crate::entity::prelude::User)
+                .col(crate::entity::user::Column::Id)
+                .col(crate::entity::user::Column::DomainId)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+        create_table(connection, schema, crate::entity::prelude::UserOption).await?;
+        create_table(connection, schema, crate::entity::prelude::LocalUser).await?;
+        create_table(connection, schema, crate::entity::prelude::Password).await?;
+        create_table(connection, schema, crate::entity::prelude::NonlocalUser).await?;
+        create_table(connection, schema, crate::entity::prelude::FederatedUser).await?;
+        create_table(connection, schema, crate::entity::prelude::Group).await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::UserGroupMembership,
+        )
+        .await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::ExpiringUserGroupMembership,
+        )
+        .await?;
+
+        Ok(())
     }
 }
 

--- a/crates/idmapping-sql/Cargo.toml
+++ b/crates/idmapping-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/idmapping-sql/src/lib.rs
+++ b/crates/idmapping-sql/src/lib.rs
@@ -14,9 +14,14 @@
 //! OpenStack Keystone SQL driver for the ID Mapping provider
 use async_trait::async_trait;
 
+use sea_orm::{DatabaseConnection, Schema};
+
 use openstack_keystone_core::identity_mapping::IdentityMappingProviderError;
 use openstack_keystone_core::identity_mapping::backend::IdentityMappingBackend;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::identity_mapping::*;
 
 pub mod entity;
@@ -24,6 +29,12 @@ mod id_mapping;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl IdentityMappingBackend for SqlBackend {
@@ -45,5 +56,17 @@ impl IdentityMappingBackend for SqlBackend {
         public_id: &'a str,
     ) -> Result<Option<IdMapping>, IdentityMappingProviderError> {
         Ok(id_mapping::get_by_public_id(&state.db, public_id).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::IdMapping).await?;
+        Ok(())
     }
 }

--- a/crates/k8s-auth-sql/Cargo.toml
+++ b/crates/k8s-auth-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/k8s-auth-sql/src/lib.rs
+++ b/crates/k8s-auth-sql/src/lib.rs
@@ -15,14 +15,25 @@
 
 use async_trait::async_trait;
 
+use sea_orm::{DatabaseConnection, Schema};
+
 use openstack_keystone_core::k8s_auth::backend::K8sAuthBackend;
 use openstack_keystone_core::k8s_auth::error::K8sAuthProviderError;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::k8s_auth::*;
 
 pub mod entity;
 mod instance;
 mod role;
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 /// Sql Database K8s auth backend.
 #[derive(Default)]
@@ -130,6 +141,29 @@ impl K8sAuthBackend for SqlBackend {
         data: K8sAuthRoleUpdate,
     ) -> Result<K8sAuthRole, K8sAuthProviderError> {
         Ok(role::update(&state.db, id, data).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::KubernetesAuthInstance,
+        )
+        .await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::KubernetesAuthRole,
+        )
+        .await?;
+        Ok(())
     }
 }
 

--- a/crates/resource-sql/Cargo.toml
+++ b/crates/resource-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/resource-sql/src/lib.rs
+++ b/crates/resource-sql/src/lib.rs
@@ -14,9 +14,13 @@
 //! # OpenStack Keystone SQL driver for the resource provider
 
 use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::resource::{ResourceProviderError, backend::ResourceBackend};
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::resource::*;
 
 mod domain;
@@ -25,6 +29,12 @@ mod project;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl ResourceBackend for SqlBackend {
@@ -147,5 +157,19 @@ impl ResourceBackend for SqlBackend {
         params: &ProjectListParameters,
     ) -> Result<Vec<Project>, ResourceProviderError> {
         Ok(project::list(&state.db, params).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::Project).await?;
+        create_table(connection, schema, crate::entity::prelude::ProjectOption).await?;
+        create_table(connection, schema, crate::entity::prelude::ProjectTag).await?;
+        Ok(())
     }
 }

--- a/crates/revoke-sql/Cargo.toml
+++ b/crates/revoke-sql/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/revoke-sql/src/lib.rs
+++ b/crates/revoke-sql/src/lib.rs
@@ -15,8 +15,13 @@
 
 use async_trait::async_trait;
 
+use sea_orm::{DatabaseConnection, Schema};
+
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::revoke::{RevokeProviderError, backend::RevokeBackend};
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::revoke::*;
 use openstack_keystone_core_types::token::Token;
 
@@ -29,6 +34,12 @@ mod list;
 /// Sql Database revocation backend.
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 impl From<db_revocation_event::Model> for RevocationEvent {
     fn from(value: db_revocation_event::Model) -> Self {
@@ -89,6 +100,18 @@ impl RevokeBackend for SqlBackend {
         Ok(create::create(&state.db, token.try_into()?)
             .await
             .map(|_| ())?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::RevocationEvent).await?;
+        Ok(())
     }
 }
 

--- a/crates/role-sql/Cargo.toml
+++ b/crates/role-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/role-sql/src/lib.rs
+++ b/crates/role-sql/src/lib.rs
@@ -12,12 +12,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! OpenStack Keystone SQL driver for the role provider
-use async_trait::async_trait;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use async_trait::async_trait;
+
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::role::RoleProviderError;
 use openstack_keystone_core::role::backend::RoleBackend;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::role::*;
 
 pub mod entity;
@@ -26,6 +32,12 @@ mod role;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl RoleBackend for SqlBackend {
@@ -111,5 +123,19 @@ impl RoleBackend for SqlBackend {
         params: &RoleListParameters,
     ) -> Result<Vec<Role>, RoleProviderError> {
         Ok(role::list(&state.db, params).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::Role).await?;
+        create_table(connection, schema, crate::entity::prelude::RoleOption).await?;
+        create_table(connection, schema, crate::entity::prelude::ImpliedRole).await?;
+        Ok(())
     }
 }

--- a/crates/token-restriction-sql/Cargo.toml
+++ b/crates/token-restriction-sql/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/token-restriction-sql/src/lib.rs
+++ b/crates/token-restriction-sql/src/lib.rs
@@ -13,10 +13,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the token restriction provider
 use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::token::TokenProviderError;
 use openstack_keystone_core::token::backend::TokenRestrictionBackend;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::token::*;
 
 use crate::entity::{token_restriction, token_restriction_role_association};
@@ -30,6 +34,12 @@ mod update;
 
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl TokenRestrictionBackend for SqlBackend {
@@ -77,6 +87,24 @@ impl TokenRestrictionBackend for SqlBackend {
         id: &'a str,
     ) -> Result<(), TokenProviderError> {
         delete::delete(&state.db, id).await
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::TokenRestriction).await?;
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::TokenRestrictionRoleAssociation,
+        )
+        .await?;
+        Ok(())
     }
 }
 

--- a/crates/trust-sql/Cargo.toml
+++ b/crates/trust-sql/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
+inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
 sea-orm.workspace = true

--- a/crates/trust-sql/src/lib.rs
+++ b/crates/trust-sql/src/lib.rs
@@ -14,10 +14,14 @@
 //! # OpenStack Keystone SQL driver for the Trust provider
 
 use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::trust::TrustProviderError;
 use openstack_keystone_core::trust::backend::TrustBackend;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
 use openstack_keystone_core_types::trust::*;
 
 pub mod entity;
@@ -26,6 +30,12 @@ mod trust;
 /// Sql Database revocation backend.
 #[derive(Default)]
 pub struct SqlBackend {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
 
 #[async_trait]
 impl TrustBackend for SqlBackend {
@@ -57,6 +67,19 @@ impl TrustBackend for SqlBackend {
         params: &TrustListParameters,
     ) -> Result<Vec<Trust>, TrustProviderError> {
         Ok(trust::list(&state.db, params).await?)
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(connection, schema, crate::entity::prelude::Trust).await?;
+        create_table(connection, schema, crate::entity::prelude::TrustRole).await?;
+        Ok(())
     }
 }
 

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -12,20 +12,13 @@ dist = false
 [dependencies]
 chrono.workspace = true
 eyre.workspace = true
+inventory.workspace = true
 itertools.workspace = true
-openstack-keystone-appcred-sql = { version = "0.1", path = "../../crates/appcred-sql/" }
-openstack-keystone-assignment-sql = { version = "0.1", path = "../../crates/assignment-sql/" }
 openstack-keystone-config = { version = "0.1", path = "../../crates/config" }
 openstack-keystone-core = { version = "0.1", path = "../../crates/core", features = ["mock"] }
 openstack-keystone-core-types = { version = "0.1", path = "../../crates/core-types" }
-openstack-keystone-federation-sql = { version = "0.1", path = "../../crates/federation-sql/" }
 openstack-keystone-identity-sql = { version = "0.1", path = "../../crates/identity-sql/" }
-openstack-keystone-k8s-auth-sql = { version = "0.1", path = "../../crates/k8s-auth-sql/" }
-openstack-keystone-resource-sql = { version = "0.1", path = "../../crates/resource-sql/" }
-openstack-keystone-role-sql = { version = "0.1", path = "../../crates/role-sql/" }
-openstack-keystone-revoke-sql = { version = "0.1", path = "../../crates/revoke-sql/" }
 openstack-keystone-token-fernet = { version = "0.1", path = "../../crates/token-fernet/" }
-openstack-keystone-token-restriction-sql = { version = "0.1", path = "../../crates/token-restriction-sql/" }
 openstack-keystone-trust-sql = { version = "0.1", path = "../../crates/trust-sql/" }
 openstack-keystone = { version = "0.1", path = "../../crates/keystone/" }
 sea-orm = { workspace = true, features = ["sqlx-sqlite"] }

--- a/tests/integration/src/application_credential/get.rs
+++ b/tests/integration/src/application_credential/get.rs
@@ -48,7 +48,7 @@ async fn test_get() -> Result<(), Report> {
                 }]),
                 description: Some("description".into()),
                 name: Uuid::new_v4().to_string(),
-                project_id: project.id.clone().into(),
+                project_id: project.id.clone(),
                 roles: vec![RoleRef::from(role_a.clone()), RoleRef::from(role_b.clone())],
                 user_id: user.id.clone(),
                 ..Default::default()

--- a/tests/integration/src/common.rs
+++ b/tests/integration/src/common.rs
@@ -20,64 +20,18 @@ use std::sync::Arc;
 
 use eyre::{Result, WrapErr};
 use sea_orm::{
-    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbConn, EntityTrait, entity::*,
-    schema::Schema, sea_query::*,
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbConn, schema::Schema,
 };
 use tempfile::TempDir;
 use uuid::Uuid;
 
-use openstack_keystone::identity::IdentityApi;
 use openstack_keystone::plugin_manager::PluginManager;
-use openstack_keystone_appcred_sql::entity::prelude::*;
 use openstack_keystone_config::Config;
-use openstack_keystone_core::keystone::Service;
 use openstack_keystone_core::policy::MockPolicy;
 use openstack_keystone_core::provider::Provider;
-use openstack_keystone_core::role::RoleApi;
-use openstack_keystone_core_types::identity::*;
-use openstack_keystone_core_types::role::RoleCreate;
-use openstack_keystone_federation_sql::entity::prelude::*;
-use openstack_keystone_identity_sql::entity::{local_user, prelude::*, user};
-use openstack_keystone_k8s_auth_sql::entity::prelude::*;
-use openstack_keystone_resource_sql::entity::{prelude::Project, project};
-use openstack_keystone_revoke_sql::entity::prelude::*;
-use openstack_keystone_role_sql::entity::prelude::*;
-use openstack_keystone_token_restriction_sql::entity::prelude::*;
-use openstack_keystone_trust_sql::entity::prelude::*;
-
-/// Create table with the related types and indexes (when known)
-async fn create_table<C, E>(conn: &C, schema: &Schema, entity: E) -> Result<()>
-where
-    C: ConnectionTrait,
-    E: EntityTrait,
-{
-    // Create types before the table
-    for ttype in schema.create_enum_from_entity(entity) {
-        conn.execute(conn.get_database_backend().build(&ttype))
-            .await?;
-    }
-    // Create the table
-    conn.execute(
-        conn.get_database_backend()
-            .build(&schema.create_table_from_entity(entity)),
-    )
-    .await?;
-    // Create related indexes
-    for tidx in schema.create_index_from_entity(entity) {
-        conn.execute(conn.get_database_backend().build(&tidx))
-            .await?;
-    }
-    Ok(())
-}
-
-async fn create_index<C>(conn: &C, index: IndexCreateStatement) -> Result<()>
-where
-    C: ConnectionTrait,
-{
-    conn.execute(conn.get_database_backend().build(&index))
-        .await?;
-    Ok(())
-}
+use openstack_keystone_core::resource::ResourceApi;
+use openstack_keystone_core::{SqlDriverRegistration, keystone::Service};
+use openstack_keystone_core_types::resource::DomainCreate;
 
 /// Setup the database schema.
 ///
@@ -88,92 +42,14 @@ pub async fn setup_schema(db: &DbConn) -> Result<()> {
     // Setup Schema helper
     let schema = Schema::new(db.get_database_backend());
 
-    create_table(db, &schema, Project).await?;
-    create_index(
-        db,
-        Index::create()
-            .name("ixu_project_name_domain_id")
-            .table(Project)
-            .col(project::Column::Name)
-            .col(project::Column::DomainId)
-            .unique()
-            .to_owned(),
-    )
-    .await?;
-    create_table(db, &schema, User).await?;
-    create_index(
-        db,
-        Index::create()
-            .name("ixu_user_id_domain_id")
-            .table(User)
-            .col(user::Column::Id)
-            .col(user::Column::DomainId)
-            .unique()
-            .to_owned(),
-    )
-    .await?;
-    create_table(db, &schema, LocalUser).await?;
-    create_index(
-        db,
-        Index::create()
-            .name("local_user_domain_id_name")
-            .table(LocalUser)
-            .col(local_user::Column::Name)
-            .col(local_user::Column::DomainId)
-            .unique()
-            .to_owned(),
-    )
-    .await?;
-    create_table(db, &schema, Password).await?;
-    create_table(db, &schema, UserOption).await?;
-    create_table(db, &schema, NonlocalUser).await?;
-    create_table(db, &schema, IdentityProvider).await?;
-    create_table(db, &schema, FederationProtocol).await?;
-    create_table(db, &schema, FederatedUser).await?;
-    create_table(db, &schema, Group).await?;
-    create_table(db, &schema, UserGroupMembership).await?;
-    create_table(db, &schema, ExpiringUserGroupMembership).await?;
-
-    create_table(db, &schema, Role).await?;
-    create_table(db, &schema, ImpliedRole).await?;
-    create_table(
-        db,
-        &schema,
-        openstack_keystone_assignment_sql::entity::prelude::Assignment,
-    )
-    .await?;
-    create_table(db, &schema, RevocationEvent).await?;
-
-    create_table(db, &schema, AccessRule).await?;
-    create_table(db, &schema, ApplicationCredential).await?;
-    create_table(db, &schema, ApplicationCredentialRole).await?;
-    create_table(db, &schema, ApplicationCredentialAccessRule).await?;
-
-    create_table(db, &schema, Trust).await?;
-    create_table(db, &schema, TrustRole).await?;
-
-    create_table(db, &schema, TokenRestriction).await?;
-    create_table(db, &schema, TokenRestrictionRoleAssociation).await?;
-    create_table(db, &schema, KubernetesAuthInstance).await?;
-    create_table(db, &schema, KubernetesAuthRole).await?;
-
-    Ok(())
-}
-
-pub async fn bootstrap(db: &DbConn) -> Result<()> {
-    // Domain/project data
-    Project::insert_many([project::ActiveModel {
-        is_domain: Set(true),
-        id: Set("<<keystone.domain.root>>".into()),
-        name: Set("<<keystone.domain.root>>".into()),
-        extra: NotSet,
-        description: NotSet,
-        enabled: Set(Some(true)),
-        domain_id: Set("<<keystone.domain.root>>".into()),
-        parent_id: NotSet,
-    }])
-    .exec(db)
-    .await?;
+    // Iterate over the registered sql plugins and let the create everything they need in the
+    // database.
+    for driver in inventory::iter::<SqlDriverRegistration>
+        .into_iter()
+        .map(|x| x.driver)
+    {
+        driver.setup(db, &schema).await?;
+    }
 
     Ok(())
 }
@@ -245,7 +121,6 @@ pub async fn get_isolated_database() -> Result<DatabaseConnection> {
 
 pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
     let db = get_isolated_database().await?;
-    bootstrap(&db).await?;
 
     let tmp_fernet_repo = TempDir::new()?;
 
@@ -269,6 +144,21 @@ pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
         Arc::new(MockPolicy::default()),
     )?);
 
+    state
+        .provider
+        .get_resource_provider()
+        .create_domain(
+            &state,
+            DomainCreate {
+                id: Some("<<keystone.domain.root>>".into()),
+                name: "<<keystone.domain.root>>".into(),
+                enabled: true,
+                extra: std::collections::HashMap::new(),
+                description: None,
+            },
+        )
+        .await
+        .unwrap();
     Ok((state, tmp_fernet_repo))
 }
 
@@ -331,61 +221,4 @@ where
     fn deref(&self) -> &Self::Target {
         &self.resource
     }
-}
-
-pub async fn create_user<U: Into<String>>(
-    state: &Arc<Service>,
-    user_id: Option<U>,
-) -> Result<UserResponse> {
-    let uid: String = user_id.map(Into::into).unwrap_or("user_id".to_string());
-    Ok(state
-        .provider
-        .get_identity_provider()
-        .create_user(
-            state,
-            UserCreateBuilder::default()
-                .id(&uid)
-                .name(&uid)
-                .domain_id("domain_a")
-                .enabled(true)
-                .build()?,
-        )
-        .await?)
-}
-
-pub async fn create_group<U: Into<String>>(
-    state: &Arc<Service>,
-    group_id: Option<U>,
-) -> Result<()> {
-    let uid: String = group_id.map(Into::into).unwrap_or("user_id".to_string());
-    state
-        .provider
-        .get_identity_provider()
-        .create_group(
-            state,
-            GroupCreateBuilder::default()
-                .id(&uid)
-                .name(&uid)
-                .domain_id("domain_a")
-                .build()?,
-        )
-        .await?;
-    Ok(())
-}
-
-pub async fn create_role<U: Into<String>>(state: &Arc<Service>, role_id: U) -> Result<()> {
-    let id: String = role_id.into();
-    state
-        .provider
-        .get_role_provider()
-        .create_role(
-            state,
-            RoleCreate {
-                id: Some(id.clone()),
-                name: id.clone(),
-                ..Default::default()
-            },
-        )
-        .await?;
-    Ok(())
 }

--- a/tests/integration/src/macros.rs
+++ b/tests/integration/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! impl_deleter {
 #[macro_export]
 macro_rules! create_domain {
     ($state:ident) => {
-        crate::resource::create_domain(
+        $crate::resource::create_domain(
             &$state,
             openstack_keystone_core_types::resource::DomainCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())
@@ -44,7 +44,7 @@ macro_rules! create_domain {
 #[macro_export]
 macro_rules! create_project {
     ($state:ident, $domain_id:expr) => {
-        crate::resource::create_project(
+        $crate::resource::create_project(
             &$state,
             openstack_keystone_core_types::resource::ProjectCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())
@@ -55,7 +55,7 @@ macro_rules! create_project {
         .await
     };
     ($state:ident, $domain_id:expr, $parent_id:expr) => {
-        crate::resource::create_project(
+        $crate::resource::create_project(
             &$state,
             openstack_keystone_core_types::resource::ProjectCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())
@@ -70,7 +70,7 @@ macro_rules! create_project {
 #[macro_export]
 macro_rules! create_role {
     ($state:ident) => {
-        crate::role::create_role(
+        $crate::role::create_role(
             &$state,
             openstack_keystone_core_types::role::RoleCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())
@@ -79,7 +79,7 @@ macro_rules! create_role {
         .await
     };
     ($state:ident, $name:expr) => {
-        crate::role::create_role(
+        $crate::role::create_role(
             &$state,
             openstack_keystone_core_types::role::RoleCreateBuilder::default()
                 .name($name)
@@ -88,7 +88,7 @@ macro_rules! create_role {
         .await
     };
     ($state:ident, $name:expr, $domain_id:expr) => {
-        crate::role::create_role(
+        $crate::role::create_role(
             &$state,
             openstack_keystone_core_types::role::RoleCreateBuilder::default()
                 .name($name)
@@ -102,7 +102,7 @@ macro_rules! create_role {
 #[macro_export]
 macro_rules! create_user {
     ($state:ident, $domain_id:expr) => {
-        crate::identity::create_user(
+        $crate::identity::create_user(
             &$state,
             openstack_keystone_core_types::identity::UserCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())
@@ -116,7 +116,7 @@ macro_rules! create_user {
 #[macro_export]
 macro_rules! create_group {
     ($state:ident, $domain_id:expr) => {
-        crate::identity::create_group(
+        $crate::identity::create_group(
             &$state,
             openstack_keystone_core_types::identity::GroupCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())
@@ -130,7 +130,7 @@ macro_rules! create_group {
 #[macro_export]
 macro_rules! create_application_credential {
     ($state:ident, $user_id:expr, $project_id:expr) => {
-        crate::application_credential::create_application_credential(
+        $crate::application_credential::create_application_credential(
             &$state,
             openstack_keystone_core_types::application_credential::ApplicationCredentialCreateBuilder::default()
                 .name(uuid::Uuid::new_v4().simple().to_string())


### PR DESCRIPTION
Start using the `inventory` crate allowing the integration test let sql
plugins themselves initialize the database as they need. In the next
steps the interface is going to be extended to address migration finally
decoupling the hardcoded migrations in the main keystone crate.
