### PR TITLE
feat: Add transaction support for Raft storage

### DIFF
--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -24,7 +24,6 @@ use tonic::transport::{Identity, ServerTlsConfig};
 use openstack_keystone_config::{Config, DistributedStorageConfiguration, TlsConfiguration};
 use openstack_keystone_distributed_storage::TypeConfig;
 use openstack_keystone_distributed_storage::app::{Storage, get_app_server, init_storage};
-use openstack_keystone_distributed_storage::network::load_tls_client_config;
 use openstack_keystone_distributed_storage::protobuf as pb;
 use openstack_keystone_distributed_storage::store_command::*;
 
@@ -227,15 +226,12 @@ async fn test_remove(instances: &Vec<Arc<InstanceHolder>>) {
 }
 
 fn bench_command_serde(c: &mut Criterion) {
-    let delete_cmd = StoreCommand::Delete(DeleteCommand {
-        key: "foo".into(),
-        keyspace: "bar".into(),
-    });
-    let set_cmd = StoreCommand::Set(SetCommand {
+    let delete_cmd = StoreCommand::Transaction(vec![Mutation::remove("foo", Some("bar")).unwrap()]);
+    let set_cmd = StoreCommand::Transaction(vec![Mutation::Set {
         key: "foo".into(),
         keyspace: "bar".into(),
         value: "value".as_bytes().to_vec(),
-    });
+    }]);
     let delete_packed = delete_cmd.pack().unwrap();
     let set_packed = set_cmd.pack().unwrap();
     let mut group = c.benchmark_group("Command_Serde");

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -112,6 +112,35 @@ pub struct Storage {
 }
 
 impl Storage {
+    /// Mutation transaction
+    ///
+    /// # Arguments
+    /// * `mutations` - List of mutations that must be applied as a single transaction.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - Success response after the value is deleted
+    /// * `Err(Status)` - Error status if the set operation fails
+    pub async fn transaction(&self, mutations: Vec<Mutation>) -> Result<(), StoreError> {
+        let request = StoreCommand::Transaction(mutations);
+        let payload = crate::pb::api::CommandRequest::try_from(request)?;
+        match self.raft.client_write(payload.clone()).await {
+            Ok(_) => {}
+            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
+                leader_id: Some(leader_id),
+                leader_node: Some(leader_node),
+            }))) => {
+                let channel = self.get_or_create_channel(leader_id, leader_node.rpc_addr)?;
+
+                let mut client = StorageServiceClient::new(channel);
+                client.command(payload).await?;
+            }
+            Err(other) => {
+                return Err(other)?;
+            }
+        };
+        Ok(())
+    }
+
     /// Deletes a value for a given key in the distributed store.
     ///
     /// # Arguments
@@ -123,13 +152,10 @@ impl Storage {
     /// * `Err(Status)` - Error status if the set operation fails
     pub async fn remove<K, S>(&self, key: K, keyspace: Option<S>) -> Result<(), StoreError>
     where
-        K: Into<String>,
+        K: Into<Vec<u8>>,
         S: Into<String>,
     {
-        let request = StoreCommand::Delete(DeleteCommand {
-            key: key.into(),
-            keyspace: keyspace.map(Into::into).unwrap_or("data".into()),
-        });
+        let request = StoreCommand::Transaction(vec![Mutation::remove(key, keyspace)?]);
         let payload = crate::pb::api::CommandRequest::try_from(request)?;
         match self.raft.client_write(payload.clone()).await {
             Ok(_) => {}
@@ -246,15 +272,9 @@ impl Storage {
         S: Into<String>,
     {
         let key: String = key.into();
-        let request = StoreCommand::Set(SetCommand {
-            key,
-            value: rmp_serde::to_vec(&value)?,
-            keyspace: keyspace.map(Into::into).unwrap_or("data".into()),
-        });
+        let request = StoreCommand::Transaction(vec![Mutation::set(key, value, keyspace)?]);
 
         let payload = crate::pb::api::CommandRequest::try_from(request)?;
-        tracing::debug!("payload is {:?}", payload);
-        tracing::debug!("state is {:?}", self.raft.metrics().borrow_watched());
         match self.raft.client_write(payload.clone()).await {
             Ok(_) => {
                 tracing::debug!("written");

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -88,6 +88,7 @@ impl FjallStateMachine {
         &self.db
     }
 
+    /// Get the reference to the Flall `keyspace` by name.
     pub fn keyspace<S: AsRef<str>>(&self, name: S) -> Result<Keyspace, StoreError> {
         Ok(self
             .db
@@ -353,22 +354,31 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
             let response = if let Some(store_req) = entry.app_data {
                 // Unpack the payload and apply the command
                 match StoreCommand::unpack(&store_req)? {
-                    StoreCommand::Delete(cmd) => {
-                        let ks = &self
-                            .db
-                            .keyspace(&cmd.keyspace, KeyspaceCreateOptions::default)
-                            .map_err(|e| io::Error::other(e.to_string()))?;
-                        batch.remove(ks, cmd.key.as_bytes());
+                    StoreCommand::Transaction(mutations) => {
+                        for mutation in mutations {
+                            match mutation {
+                                Mutation::Remove { key, keyspace } => {
+                                    let ks = &self
+                                        .db
+                                        .keyspace(&keyspace, KeyspaceCreateOptions::default)
+                                        .map_err(|e| io::Error::other(e.to_string()))?;
+                                    batch.remove(ks, key);
+                                }
+                                Mutation::Set {
+                                    key,
+                                    keyspace,
+                                    value,
+                                } => {
+                                    let ks = &self
+                                        .db
+                                        .keyspace(&keyspace, KeyspaceCreateOptions::default)
+                                        .map_err(|e| io::Error::other(e.to_string()))?;
+                                    // TODO: at REST encryption would come here
+                                    batch.insert(ks, key, value);
+                                }
+                            }
+                        }
                         None
-                    }
-                    StoreCommand::Set(cmd) => {
-                        let ks = &self
-                            .db
-                            .keyspace(&cmd.keyspace, KeyspaceCreateOptions::default)
-                            .map_err(|e| io::Error::other(e.to_string()))?;
-                        // TODO: at REST encryption would come here
-                        batch.insert(ks, cmd.key.as_bytes(), cmd.value.clone());
-                        Some(cmd.value)
                     }
                 }
             } else if let Some(mem) = entry.membership {

--- a/crates/storage/src/store_command.rs
+++ b/crates/storage/src/store_command.rs
@@ -17,41 +17,67 @@ use serde::{Deserialize, Serialize};
 
 use crate::StoreError;
 
-/// Store modification command.
+/// Store command.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum StoreCommand {
+    /// Store mutation transaction.
+    Transaction(Vec<Mutation>),
+}
+
+/// Store modification operation.
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub enum Mutation {
     /// Delete the entry from the store.
-    Delete(DeleteCommand),
+    Remove {
+        /// The Key to delete.
+        key: Vec<u8>,
+
+        /// The `keyspace` of the key.
+        keyspace: String,
+    },
+
     /// Set the value for the key in the store.
-    Set(SetCommand),
+    Set {
+        /// The key to set.
+        key: Vec<u8>,
+
+        /// The `keyspace` of the key.
+        keyspace: String,
+
+        /// The value to set.
+        #[serde(with = "serde_bytes")]
+        value: Vec<u8>,
+    },
 }
 
-/// Command to delete the value from the store.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct DeleteCommand {
-    /// Key to delete.
-    pub key: String,
+impl Mutation {
+    pub fn remove<K, S>(key: K, keyspace: Option<S>) -> Result<Self, StoreError>
+    where
+        K: Into<Vec<u8>>,
+        S: Into<String>,
+    {
+        Ok(Self::Remove {
+            key: key.into(),
+            keyspace: keyspace.map(Into::into).unwrap_or("data".into()),
+        })
+    }
 
-    /// Keyspace of the key.
-    pub keyspace: String,
-}
-
-/// Command to set the value in the store.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct SetCommand {
-    /// Key to set.
-    pub key: String,
-
-    /// Keyspace of the key.
-    pub keyspace: String,
-
-    /// Value to set.
-    #[serde(with = "serde_bytes")]
-    pub value: Vec<u8>,
+    pub fn set<K, V, S>(key: K, value: V, keyspace: Option<S>) -> Result<Self, StoreError>
+    where
+        K: Into<Vec<u8>>,
+        V: Serialize,
+        S: Into<String>,
+    {
+        Ok(Self::Set {
+            key: key.into(),
+            value: rmp_serde::to_vec(&value)?,
+            keyspace: keyspace.map(Into::into).unwrap_or("data".into()),
+        })
+    }
 }
 
 impl StoreCommand {
-    /// Pack the [StoreCommand] into the format safe for the Raft log.
+    /// Pack the [`StoreCommand`] into the format safe for the Raft log.
     ///
     /// Serialize the data into the bytes using the MsgPack format.
     ///
@@ -83,10 +109,9 @@ mod tests {
 
     #[test]
     fn test_delete_command() {
-        let cmd = StoreCommand::Delete(DeleteCommand {
-            key: "foo".into(),
-            keyspace: "bar".into(),
-        });
+        let mutation = Mutation::remove("foo", Some("bar")).unwrap();
+        let cmd = StoreCommand::Transaction(vec![mutation]);
+
         let packed = cmd.pack().unwrap();
         let unpacked = StoreCommand::unpack(&packed).unwrap();
         assert_eq!(cmd, unpacked);
@@ -94,16 +119,16 @@ mod tests {
 
     #[test]
     fn test_set_command() {
-        let cmd = StoreCommand::Set(SetCommand {
-            key: "foo".into(),
-            keyspace: "bar".into(),
-            value: "value".as_bytes().to_vec(),
-        });
+        let mutation = Mutation::set("foo", "value", Some("bar")).unwrap();
+        let cmd = StoreCommand::Transaction(vec![mutation]);
         let packed = cmd.pack().unwrap();
         let unpacked = StoreCommand::unpack(&packed).unwrap();
         assert_eq!(cmd, unpacked);
-        if let StoreCommand::Set(cmd) = unpacked {
-            assert_eq!("value", str::from_utf8(&cmd.value).unwrap());
+        if let StoreCommand::Transaction(data) = unpacked
+            && let Some(mutation) = data.first()
+            && let Mutation::Set { value, .. } = mutation
+        {
+            assert_eq!(value, &rmp_serde::to_vec("value").unwrap());
         } else {
             panic!("should be the set command");
         }

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -37,6 +37,7 @@ use openstack_keystone_distributed_storage::app::{Storage, get_app_server, init_
 use openstack_keystone_distributed_storage::network::load_tls_client_config;
 use openstack_keystone_distributed_storage::protobuf as pb;
 use openstack_keystone_distributed_storage::protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient;
+use openstack_keystone_distributed_storage::store_command::*;
 
 /// Set up a cluster of 3 nodes.
 /// Write to it and read from it.
@@ -46,6 +47,7 @@ fn test_cluster() {
     TypeConfig::run(test_cluster_inner()).unwrap();
 }
 
+#[allow(dead_code)]
 struct InstanceHolder {
     pub node_id: u64,
     pub config: Config,
@@ -246,6 +248,38 @@ async fn test_cluster_inner() -> Result<()> {
             assert_eq!(Some("bar1".to_string()), got);
         }
     }
+
+    println!("=== Transaction test");
+
+    let mutations = vec![
+        Mutation::set("new_foo", "new_val", None::<&str>)?,
+        Mutation::set("new_foo2", "new_val2", None::<&str>)?,
+        Mutation::remove("foo1", Some("another_keyspace"))?,
+    ];
+    instance1.storage.transaction(mutations).await?;
+    assert_eq!(
+        "new_val",
+        instance1
+            .storage
+            .get_by_key::<String, &str, &str>("new_foo", None)
+            .await?
+            .expect("data should be there")
+    );
+    assert_eq!(
+        "new_val2",
+        instance1
+            .storage
+            .get_by_key::<String, &str, &str>("new_foo2", None)
+            .await?
+            .expect("data should be there")
+    );
+    assert!(
+        instance1
+            .storage
+            .get_by_key::<String, &str, &str>("foo1", Some("another_keyspace"))
+            .await?
+            .is_none()
+    );
 
     println!("=== Remove node 1,2 by change-membership to {{3}}");
     {


### PR DESCRIPTION
Providers need to write multiple data mutations within one transaction.
Change the StoreCommand to take a vector of mutation operations.
