### PR TITLE
feat: Add metadata for raft data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,6 +3689,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "byteorder",
+ "chrono",
  "criterion",
  "dashmap",
  "eyre",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -17,6 +17,14 @@ workspace = true
 name = "write"
 harness = false
 
+[[bench]]
+name = "encryption"
+harness = false
+
+[[bench]]
+name = "state_machine"
+harness = false
+
 [dependencies]
 async-trait.workspace = true
 byteorder.workspace = true
@@ -39,6 +47,7 @@ tonic = { workspace = true, features = ["router", "_tls-any"] }
 tonic-prost.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
@@ -55,3 +64,6 @@ all-features = true
 
 [build-dependencies]
 tonic-prost-build.workspace = true
+
+[features]
+bench_internals = []

--- a/crates/storage/benches/encryption.rs
+++ b/crates/storage/benches/encryption.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "bench_internals")]
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use openstack_keystone_distributed_storage::{
+    Metadata, Nonce, bench_pack, bench_unpack, store_command::*,
+};
+
+fn bench_encryption(c: &mut Criterion) {
+    let data = rmp_serde::to_vec("foo").unwrap();
+
+    let mut group = c.benchmark_group("Payload_encryption");
+
+    group.bench_with_input(BenchmarkId::new("pack", "inner"), &data, |b, data| {
+        b.iter(|| bench_pack(black_box(data)));
+    });
+
+    let packed = bench_pack(&data).unwrap();
+
+    group.bench_with_input(BenchmarkId::new("unpack", "inner"), &packed, |b, data| {
+        b.iter(|| bench_unpack(black_box(&data)));
+    });
+
+    let remove_cmd = StoreCommand::Transaction(vec![
+        MutationInner::convert(
+            Mutation::remove("foo", Some("bar")).unwrap(),
+            Nonce::default(),
+        )
+        .unwrap(),
+    ]);
+    let set_cmd = StoreCommand::Transaction(vec![
+        MutationInner::convert(
+            Mutation::set("foo", "bar", Metadata::new(), Some("bar"), None).unwrap(),
+            Nonce::default(),
+        )
+        .unwrap(),
+    ]);
+    group.bench_with_input(
+        BenchmarkId::new("pack", "remove_cmd"),
+        &remove_cmd,
+        |b, data| {
+            b.iter(|| data.pack().unwrap());
+        },
+    );
+    group.bench_with_input(BenchmarkId::new("pack", "set_cmd"), &set_cmd, |b, data| {
+        b.iter(|| data.pack().unwrap());
+    });
+    let packed = remove_cmd.pack().unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("unpack", "remove_cmd"),
+        &packed,
+        |b, data| {
+            b.iter(|| StoreCommand::unpack(black_box(data)).unwrap());
+        },
+    );
+    let packed = set_cmd.pack().unwrap();
+    group.bench_with_input(BenchmarkId::new("unpack", "set_cmd"), &packed, |b, data| {
+        b.iter(|| StoreCommand::unpack(black_box(data)).unwrap());
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_encryption);
+criterion_main!(benches);

--- a/crates/storage/benches/state_machine.rs
+++ b/crates/storage/benches/state_machine.rs
@@ -1,0 +1,121 @@
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use fjall::Database;
+use futures::stream;
+use openraft::{RaftSnapshotBuilder, storage::RaftStateMachine};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+use openstack_keystone_distributed_storage::pb::raft::Entry;
+use openstack_keystone_distributed_storage::store_command::{
+    Mutation, MutationInner, StoreCommand,
+};
+use openstack_keystone_distributed_storage::{FjallStateMachine, Metadata, Nonce};
+
+fn bench_state_machine(c: &mut Criterion) {
+    let db_path = TempDir::new().unwrap();
+    let snapshot_dir = db_path.path().join("snapshots");
+    let db = Database::builder(db_path).open().unwrap();
+    let db = Arc::new(db);
+    let sm = Arc::new(FjallStateMachine::new(db, snapshot_dir).unwrap());
+
+    c.bench_function("get_db", |b| {
+        b.iter(|| sm.db());
+    });
+    c.bench_function("get_data_keyspace", |b| {
+        b.iter(|| sm.data());
+    });
+
+    c.bench_function("get_keyspace", |b| {
+        b.iter(|| sm.keyspace("index"));
+    });
+
+    let rt = Runtime::new().unwrap();
+    c.bench_with_input(
+        BenchmarkId::new("build_snapshot", "default"),
+        &sm,
+        |b, sm| {
+            b.to_async(&rt).iter_batched(
+                // init
+                || sm.clone(),
+                // run
+                |mut sm| async move {
+                    let _ = sm.build_snapshot().await;
+                    black_box(sm);
+                },
+                BatchSize::PerIteration,
+            );
+        },
+    );
+    let mut group = c.benchmark_group("Command_Serde");
+    let set_transaction = StoreCommand::Transaction(vec![
+        MutationInner::convert(
+            Mutation::set("foo", "bar", Metadata::new(), Some("data"), None).unwrap(),
+            Nonce::default(),
+        )
+        .unwrap(),
+    ])
+    .pack()
+    .unwrap();
+    let remove_transaction = StoreCommand::Transaction(vec![
+        MutationInner::convert(
+            Mutation::remove("foo", Some("data")).unwrap(),
+            Nonce::default(),
+        )
+        .unwrap(),
+    ])
+    .pack()
+    .unwrap();
+    group.bench_with_input(BenchmarkId::new("apply", "set"), &sm, |b, sm| {
+        b.to_async(&rt).iter_batched(
+            // init
+            || {
+                let data = vec![Ok((
+                    Entry {
+                        term: 1,
+                        index: 2,
+                        app_data: Some(set_transaction.clone()),
+                        membership: None,
+                    },
+                    None,
+                ))];
+                (sm.clone(), stream::iter(data))
+            },
+            // run
+            |(mut sm, strm)| async move {
+                let _ = sm.apply(strm).await;
+                black_box(sm);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.bench_with_input(BenchmarkId::new("apply", "remove"), &sm, |b, sm| {
+        b.to_async(&rt).iter_batched(
+            // init
+            || {
+                let data = vec![Ok((
+                    Entry {
+                        term: 1,
+                        index: 2,
+                        app_data: Some(remove_transaction.clone()),
+                        membership: None,
+                    },
+                    None,
+                ))];
+                (sm.clone(), stream::iter(data))
+            },
+            // run
+            |(mut sm, strm)| async move {
+                let _ = sm.apply(strm).await;
+                black_box(sm);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_state_machine);
+criterion_main!(benches);

--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -22,10 +22,10 @@ use tokio::runtime::Runtime;
 use tonic::transport::{Identity, ServerTlsConfig};
 
 use openstack_keystone_config::{Config, DistributedStorageConfiguration, TlsConfiguration};
-use openstack_keystone_distributed_storage::TypeConfig;
 use openstack_keystone_distributed_storage::app::{Storage, get_app_server, init_storage};
 use openstack_keystone_distributed_storage::protobuf as pb;
 use openstack_keystone_distributed_storage::store_command::*;
+use openstack_keystone_distributed_storage::{Metadata, Nonce, StoreDataEnvelope, TypeConfig};
 
 #[allow(dead_code)]
 struct InstanceHolder {
@@ -201,7 +201,7 @@ async fn build_cluster(count_nodes: u64) -> Result<Vec<Arc<InstanceHolder>>> {
 async fn test_write(instances: &Vec<Arc<InstanceHolder>>) {
     if let Some(inst) = instances.first() {
         inst.storage
-            .set_value("foo", "barz", None::<&str>)
+            .set_value("foo", StoreDataEnvelope::from("barz"), None::<&str>, None)
             .await
             .unwrap();
     }
@@ -209,13 +209,15 @@ async fn test_write(instances: &Vec<Arc<InstanceHolder>>) {
 
 async fn test_read(instances: &Vec<Arc<InstanceHolder>>) {
     if let Some(inst) = instances.first() {
-        let _: Option<String> = inst.storage.get_by_key("foo", None::<&str>).await.unwrap();
+        let _: Option<StoreDataEnvelope<String>> =
+            inst.storage.get_by_key("foo", None::<&str>).await.unwrap();
     }
 }
 
 async fn test_prefix(instances: &Vec<Arc<InstanceHolder>>) {
     if let Some(inst) = instances.first() {
-        let _: Vec<(String, String)> = inst.storage.prefix("foo", None::<&str>).await.unwrap();
+        let _: Vec<(String, StoreDataEnvelope<String>)> =
+            inst.storage.prefix("foo", None::<&str>).await.unwrap();
     }
 }
 
@@ -226,12 +228,20 @@ async fn test_remove(instances: &Vec<Arc<InstanceHolder>>) {
 }
 
 fn bench_command_serde(c: &mut Criterion) {
-    let delete_cmd = StoreCommand::Transaction(vec![Mutation::remove("foo", Some("bar")).unwrap()]);
-    let set_cmd = StoreCommand::Transaction(vec![Mutation::Set {
-        key: "foo".into(),
-        keyspace: "bar".into(),
-        value: "value".as_bytes().to_vec(),
-    }]);
+    let delete_cmd = StoreCommand::Transaction(vec![
+        MutationInner::convert(
+            Mutation::remove("foo", Some("bar")).unwrap(),
+            Nonce::default(),
+        )
+        .unwrap(),
+    ]);
+    let set_cmd = StoreCommand::Transaction(vec![
+        MutationInner::convert(
+            Mutation::set("foo", "bar", Metadata::new(), Some("bar"), None).unwrap(),
+            Nonce::default(),
+        )
+        .unwrap(),
+    ]);
     let delete_packed = delete_cmd.pack().unwrap();
     let set_packed = set_cmd.pack().unwrap();
     let mut group = c.benchmark_group("Command_Serde");

--- a/crates/storage/build.rs
+++ b/crates/storage/build.rs
@@ -25,6 +25,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("keystone.raft.Vote", "#[derive(Deserialize, Serialize)]")
         .type_attribute("keystone.api.Response", "#[derive(Deserialize, Serialize)]")
         .type_attribute(
+            "keystone.api.Response.Violation",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
             "keystone.api.CommandRequest",
             "#[derive(Deserialize, Serialize)]",
         )

--- a/crates/storage/proto/storage_types.proto
+++ b/crates/storage/proto/storage_types.proto
@@ -11,4 +11,11 @@ message CommandRequest {
 message Response {
   // Retrieved value.
   optional bytes value = 1;
+
+  message Violation {
+    string type = 1;        // Use "REVISION_MISMATCH"
+    string subject = 2;     // The Resource ID
+    string description = 3; // e.g., "Current revision is 5, provided was 4"
+  }
+  repeated Violation violations = 2;
 }

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use openraft::Config;
-// use openraft::ReadPolicy;
 use openraft::async_runtime::WatchReceiver;
 use openraft::errors::{ForwardToLeader, RaftError};
 use serde::Serialize;
@@ -121,7 +120,14 @@ impl Storage {
     /// * `Ok(Response)` - Success response after the value is deleted
     /// * `Err(Status)` - Error status if the set operation fails
     pub async fn transaction(&self, mutations: Vec<Mutation>) -> Result<(), StoreError> {
-        let request = StoreCommand::Transaction(mutations);
+        let metrics = self.raft.metrics().borrow_watched().clone();
+        let nonce = Nonce::new(metrics.current_term, metrics.last_log_index.unwrap_or(1));
+        let request = StoreCommand::Transaction(
+            mutations
+                .into_iter()
+                .map(|x| MutationInner::convert(x, nonce.clone()))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
         let payload = crate::pb::api::CommandRequest::try_from(request)?;
         match self.raft.client_write(payload.clone()).await {
             Ok(_) => {}
@@ -155,7 +161,10 @@ impl Storage {
         K: Into<Vec<u8>>,
         S: Into<String>,
     {
-        let request = StoreCommand::Transaction(vec![Mutation::remove(key, keyspace)?]);
+        let request = StoreCommand::Transaction(vec![MutationInner::convert(
+            Mutation::remove(key, keyspace)?,
+            Nonce::default(),
+        )?]);
         let payload = crate::pb::api::CommandRequest::try_from(request)?;
         match self.raft.client_write(payload.clone()).await {
             Ok(_) => {}
@@ -188,7 +197,7 @@ impl Storage {
         &self,
         key: K,
         keyspace: Option<S>,
-    ) -> Result<Option<T>, StoreError>
+    ) -> Result<Option<StoreDataEnvelope<T>>, StoreError>
     where
         T: DeserializeOwned,
         K: AsRef<[u8]>,
@@ -201,12 +210,25 @@ impl Storage {
             None => self.state_machine_store.data(),
             Some(name) => &self.state_machine_store.keyspace(name)?,
         };
-        let value = ks
+        // NOTE: running lookups in separate tasks make huge negative performance impact (+1000%).
+        if let Some(data) = ks
             .get(&key)?
-            .map(|x| rmp_serde::from_slice(x.as_ref()))
-            .transpose()?;
-        // TODO: at REST decryption would come here
-        Ok(value)
+            .map(|x| StoreDataInnerEnvelope::unpack(x.as_ref()))
+            .transpose()?
+        {
+            let metadata = if let Some(meta) = self.state_machine_store.meta().get(&key)? {
+                Metadata::unpack(&meta)?
+            } else {
+                // Need to repair data and insert the new metadata
+                let res = Metadata::new();
+                self.state_machine_store
+                    .meta()
+                    .insert(key.as_ref(), res.pack()?)?;
+                res
+            };
+            return Ok(Some(StoreDataEnvelope { data, metadata }));
+        }
+        Ok(None)
     }
 
     /// List key value pairs by the prefix.
@@ -225,7 +247,7 @@ impl Storage {
         &self,
         prefix: K,
         keyspace: Option<S>,
-    ) -> Result<Vec<(String, T)>, StoreError>
+    ) -> Result<Vec<(String, StoreDataEnvelope<T>)>, StoreError>
     where
         T: DeserializeOwned,
         K: AsRef<[u8]>,
@@ -238,13 +260,26 @@ impl Storage {
             None => self.state_machine_store.data(),
             Some(name) => &self.state_machine_store.keyspace(name)?,
         };
-        // TODO: at REST decryption would come here
         ks.prefix(&prefix)
             .map(|item| {
                 let (key, val) = item.into_inner()?;
+                let k = String::from_utf8(key.to_vec())?;
+                let meta = if let Some(meta) = self.state_machine_store.meta().get(&k)? {
+                    Metadata::unpack(&meta)?
+                } else {
+                    // Need to repair data and insert the new metadata
+                    let res = Metadata::new();
+                    self.state_machine_store
+                        .meta()
+                        .insert(k.clone(), res.pack()?)?;
+                    res
+                };
                 Ok((
-                    String::from_utf8(key.to_vec())?,
-                    rmp_serde::from_slice(val.as_ref())?,
+                    k.clone(),
+                    StoreDataEnvelope {
+                        data: StoreDataInnerEnvelope::unpack(val.as_ref())?,
+                        metadata: meta,
+                    },
                 ))
             })
             .collect()
@@ -263,8 +298,9 @@ impl Storage {
     pub async fn set_value<K, V, S>(
         &self,
         key: K,
-        value: V,
+        value: StoreDataEnvelope<V>,
         keyspace: Option<S>,
+        expected_revision: Option<u64>,
     ) -> Result<(), StoreError>
     where
         K: Into<String>,
@@ -272,25 +308,26 @@ impl Storage {
         S: Into<String>,
     {
         let key: String = key.into();
-        let request = StoreCommand::Transaction(vec![Mutation::set(key, value, keyspace)?]);
+        let metrics = self.raft.metrics().borrow_watched().clone();
+        let nonce = Nonce::new(metrics.current_term, metrics.last_log_index.unwrap_or(1));
+        let request = StoreCommand::Transaction(vec![MutationInner::convert(
+            Mutation::set(key, value.data, value.metadata, keyspace, expected_revision)?,
+            nonce,
+        )?]);
 
         let payload = crate::pb::api::CommandRequest::try_from(request)?;
         match self.raft.client_write(payload.clone()).await {
-            Ok(_) => {
-                tracing::debug!("written");
-            }
+            Ok(_) => {}
             Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
                 leader_id: Some(leader_id),
                 leader_node: Some(leader_node),
             }))) => {
-                tracing::debug!("need to redirect to {:?}", leader_id);
                 let channel = self.get_or_create_channel(leader_id, leader_node.rpc_addr)?;
 
                 let mut client = StorageServiceClient::new(channel);
                 client.command(payload).await?;
             }
             Err(other) => {
-                tracing::debug!("error {:?}", other);
                 return Err(other)?;
             }
         };
@@ -304,7 +341,7 @@ impl Storage {
 
     /// Get the channel to the given node.
     ///
-    /// Get the channel to the node if it is already establed or create a new one. This method uses
+    /// Get the channel to the node if it is already established or create a new one. This method uses
     /// the connection pool.
     ///
     /// # Arguments

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -33,6 +33,13 @@ pub enum StoreError {
         source: std::io::Error,
     },
 
+    /// Tasks join error.
+    #[error(transparent)]
+    Join {
+        #[from]
+        source: tokio::task::JoinError,
+    },
+
     #[error(transparent)]
     Json {
         #[from]

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -52,6 +52,9 @@ pub mod protobuf {
     }
 }
 pub use crate::protobuf as pb;
+pub use types::{Metadata, Nonce, StoreDataEnvelope};
+#[cfg(feature = "bench_internals")]
+pub use types::{bench_pack, bench_unpack};
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -41,7 +41,9 @@ use serde::Serialize;
 use crate::StoreError;
 use crate::TypeConfig;
 use crate::protobuf as pb;
+use crate::protobuf::api::response::Violation;
 use crate::store_command::*;
+use crate::types::{Metadata, StoreDataInnerEnvelope};
 
 const KEY_LAST_APPLIED_LOG: &[u8] = b"last_applied_log";
 const KEY_LAST_MEMBERSHIP: &[u8] = b"last_membership";
@@ -61,6 +63,7 @@ pub struct FjallStateMachine {
     db: Arc<Database>,
     meta: Keyspace,
     data: Keyspace,
+    index: Keyspace,
     snapshot_dir: PathBuf,
 }
 
@@ -69,6 +72,7 @@ impl FjallStateMachine {
     pub fn new(db: Arc<Database>, snapshot_dir: PathBuf) -> Result<Self, StoreError> {
         let meta = db.keyspace("meta", KeyspaceCreateOptions::default)?;
         let data = db.keyspace("data", KeyspaceCreateOptions::default)?;
+        let index = db.keyspace("index", KeyspaceCreateOptions::default)?;
 
         fs::create_dir_all(&snapshot_dir)?;
 
@@ -77,22 +81,37 @@ impl FjallStateMachine {
             snapshot_dir,
             meta,
             data,
+            index,
         })
     }
 
-    pub fn data(&self) -> &Keyspace {
-        &self.data
-    }
-
+    /// Get the database handle.
     pub fn db(&self) -> &Arc<Database> {
         &self.db
     }
 
-    /// Get the reference to the Flall `keyspace` by name.
+    /// Get the data `keyspace` handle.
+    pub fn data(&self) -> &Keyspace {
+        &self.data
+    }
+
+    /// Get the metadata `keyspace` handle.
+    pub fn meta(&self) -> &Keyspace {
+        &self.meta
+    }
+
+    /// Get the Flall `keyspace` handle by name.
+    ///
+    /// Get a handle to the keyspace creating a new one when not exists.
     pub fn keyspace<S: AsRef<str>>(&self, name: S) -> Result<Keyspace, StoreError> {
-        Ok(self
-            .db
-            .keyspace(name.as_ref(), KeyspaceCreateOptions::default)?)
+        Ok(match name.as_ref() {
+            "data" => self.data.clone(),
+            "meta" => self.meta.clone(),
+            "index" => self.index.clone(),
+            other => self
+                .db
+                .keyspace(other.as_ref(), KeyspaceCreateOptions::default)?,
+        })
     }
 
     #[allow(clippy::result_large_err)]
@@ -116,11 +135,11 @@ impl FjallStateMachine {
 }
 
 fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, StorageError<TypeConfig>> {
-    serde_json::to_vec(value).map_err(|e| StorageError::write(TypeConfig::err_from_error(&e)))
+    rmp_serde::to_vec(value).map_err(|e| StorageError::write(TypeConfig::err_from_error(&e)))
 }
 
 fn deserialize<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, StorageError<TypeConfig>> {
-    serde_json::from_slice(bytes).map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))
+    rmp_serde::from_slice(bytes).map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<FjallStateMachine> {
@@ -326,11 +345,11 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
 
         // Read and deserialize snapshot file
         let file_bytes = fs::read(&snapshot_path)?;
-        let snapshot_file: SnapshotFile = serde_json::from_slice(&file_bytes)
+        let snapshot_file: SnapshotFile = rmp_serde::from_slice(&file_bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         // Serialize data for snapshot field
-        let data_bytes = serde_json::to_vec(&snapshot_file.data)
+        let data_bytes = rmp_serde::to_vec(&snapshot_file.data)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         Ok(Some(Snapshot {
@@ -355,30 +374,72 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                 // Unpack the payload and apply the command
                 match StoreCommand::unpack(&store_req)? {
                     StoreCommand::Transaction(mutations) => {
+                        let mut violations: Vec<Violation> = Vec::new();
                         for mutation in mutations {
                             match mutation {
-                                Mutation::Remove { key, keyspace } => {
-                                    let ks = &self
-                                        .db
-                                        .keyspace(&keyspace, KeyspaceCreateOptions::default)
-                                        .map_err(|e| io::Error::other(e.to_string()))?;
-                                    batch.remove(ks, key);
+                                MutationInner::Remove { key, keyspace } => {
+                                    // Protect own data
+                                    if keyspace == "meta" && key == KEY_LAST_MEMBERSHIP
+                                        || key == KEY_LAST_APPLIED_LOG
+                                    {
+                                        return Err(io::Error::other(
+                                            "not allowed to delete system data",
+                                        ));
+                                    }
+                                    let ks = &self.keyspace(keyspace)?;
+                                    batch.remove(ks, key.clone());
+                                    batch.remove(&self.meta, key.clone());
                                 }
-                                Mutation::Set {
+                                MutationInner::Set {
                                     key,
                                     keyspace,
-                                    value,
+                                    cipher,
+                                    metadata,
+                                    nonce,
+                                    expected_revision,
                                 } => {
-                                    let ks = &self
-                                        .db
-                                        .keyspace(&keyspace, KeyspaceCreateOptions::default)
-                                        .map_err(|e| io::Error::other(e.to_string()))?;
-                                    // TODO: at REST encryption would come here
-                                    batch.insert(ks, key, value);
+                                    // Protect own data
+                                    if keyspace == "meta" && key == KEY_LAST_MEMBERSHIP
+                                        || key == KEY_LAST_APPLIED_LOG
+                                    {
+                                        return Err(io::Error::other(
+                                            "not allowed to overwrite system data",
+                                        ));
+                                    }
+                                    if let Some(expected_revision) = expected_revision {
+                                        let curr_meta = self
+                                            .meta()
+                                            .get(&key)
+                                            .map_err(|e| io::Error::other(e.to_string()))?
+                                            .map(|x| Metadata::unpack(x.as_ref()))
+                                            .transpose()?;
+                                        if !curr_meta
+                                            .as_ref()
+                                            .is_some_and(|x| x.revision == expected_revision)
+                                        {
+                                            violations.push(Violation {
+                                                r#type: "CONFLICT".to_string(),
+                                                subject: String::from_utf8_lossy(&key).to_string(),
+                                                description: format!(
+                                                    "Current revision is {:?} while {} was expected",
+                                                    curr_meta.map(|x| x.revision),
+                                                    expected_revision
+                                                ),
+                                            });
+                                        }
+                                    }
+                                    let ks = &self.keyspace(keyspace)?;
+                                    let inner_data = StoreDataInnerEnvelope {
+                                        cipher: cipher,
+                                        nonce: nonce,
+                                    }
+                                    .pack()?;
+                                    batch.insert(ks, key.clone(), inner_data);
+                                    batch.insert(&self.meta, key.clone(), metadata.pack()?);
                                 }
                             }
                         }
-                        None
+                        (None, violations)
                     }
                 }
             } else if let Some(mem) = entry.membership {
@@ -386,26 +447,29 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                     last_applied_log,
                     mem.try_into()?,
                 ));
-                None
+                (None, vec![])
             } else {
-                None
+                (None, vec![])
             };
             if let Some(responder) = responder {
-                responder.send(pb::api::Response { value: response });
+                responder.send(pb::api::Response {
+                    value: response.0,
+                    violations: response.1,
+                });
             }
         }
         if let Some(val) = last_membership {
             batch.insert(
                 &self.meta,
                 KEY_LAST_MEMBERSHIP,
-                serde_json::to_vec(&val).map_err(|e| io::Error::other(e.to_string()))?,
+                rmp_serde::to_vec(&val).map_err(|e| io::Error::other(e.to_string()))?,
             );
         }
         if let Some(val) = last_applied_log {
             batch.insert(
                 &self.meta,
                 KEY_LAST_APPLIED_LOG,
-                serde_json::to_vec(&val).map_err(|e| io::Error::other(e.to_string()))?,
+                rmp_serde::to_vec(&val).map_err(|e| io::Error::other(e.to_string()))?,
             );
         }
 

--- a/crates/storage/src/store_command.rs
+++ b/crates/storage/src/store_command.rs
@@ -16,12 +16,79 @@
 use serde::{Deserialize, Serialize};
 
 use crate::StoreError;
+use crate::types::{Metadata, Nonce};
 
 /// Store command.
+///
+/// An operation to be performed on the storage. The data is transferred encrypted over the wire
+/// since it is stored in the raft log files.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum StoreCommand {
     /// Store mutation transaction.
-    Transaction(Vec<Mutation>),
+    Transaction(Vec<MutationInner>),
+}
+
+/// Inner representation of the store modification operation encrypting the data for at-rest
+/// storage.
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub enum MutationInner {
+    /// Delete the entry from the store.
+    Remove {
+        /// The Key to delete.
+        key: Vec<u8>,
+
+        /// The `keyspace` of the key.
+        keyspace: String,
+    },
+
+    /// Set the value for the key in the store.
+    Set {
+        /// The value to set.
+        #[serde(with = "serde_bytes")]
+        cipher: Vec<u8>,
+
+        /// Expected revision.
+        expected_revision: Option<u64>,
+
+        /// The key to set.
+        key: Vec<u8>,
+
+        /// The `keyspace` of the key.
+        keyspace: String,
+
+        /// The resource metadata.
+        metadata: Metadata,
+
+        /// Nonce.
+        nonce: Nonce,
+    },
+}
+
+impl MutationInner {
+    /// Convert the mutation operation into the Raft operation.
+    ///
+    /// Convert the mutation command into the raft operation encrypting the data for the at-rest
+    /// encryption.
+    pub fn convert(value: Mutation, nonce: Nonce) -> Result<MutationInner, StoreError> {
+        Ok(match value {
+            Mutation::Remove { key, keyspace } => MutationInner::Remove { key, keyspace },
+            Mutation::Set {
+                key,
+                keyspace,
+                value,
+                metadata,
+                expected_revision,
+            } => MutationInner::Set {
+                key,
+                keyspace,
+                metadata,
+                // TODO: encrypt for at-rest
+                cipher: value,
+                nonce,
+                expected_revision,
+            },
+        })
+    }
 }
 
 /// Store modification operation.
@@ -38,11 +105,17 @@ pub enum Mutation {
 
     /// Set the value for the key in the store.
     Set {
+        /// Expected revision.
+        expected_revision: Option<u64>,
+
         /// The key to set.
         key: Vec<u8>,
 
         /// The `keyspace` of the key.
         keyspace: String,
+
+        /// The resource metadata.
+        metadata: Metadata,
 
         /// The value to set.
         #[serde(with = "serde_bytes")]
@@ -62,7 +135,13 @@ impl Mutation {
         })
     }
 
-    pub fn set<K, V, S>(key: K, value: V, keyspace: Option<S>) -> Result<Self, StoreError>
+    pub fn set<K, V, S>(
+        key: K,
+        value: V,
+        metadata: Metadata,
+        keyspace: Option<S>,
+        expected_revision: Option<u64>,
+    ) -> Result<Self, StoreError>
     where
         K: Into<Vec<u8>>,
         V: Serialize,
@@ -72,6 +151,8 @@ impl Mutation {
             key: key.into(),
             value: rmp_serde::to_vec(&value)?,
             keyspace: keyspace.map(Into::into).unwrap_or("data".into()),
+            metadata: metadata,
+            expected_revision,
         })
     }
 }
@@ -110,7 +191,9 @@ mod tests {
     #[test]
     fn test_delete_command() {
         let mutation = Mutation::remove("foo", Some("bar")).unwrap();
-        let cmd = StoreCommand::Transaction(vec![mutation]);
+        let cmd = StoreCommand::Transaction(vec![
+            MutationInner::convert(mutation, Nonce::default()).unwrap(),
+        ]);
 
         let packed = cmd.pack().unwrap();
         let unpacked = StoreCommand::unpack(&packed).unwrap();
@@ -119,16 +202,19 @@ mod tests {
 
     #[test]
     fn test_set_command() {
-        let mutation = Mutation::set("foo", "value", Some("bar")).unwrap();
-        let cmd = StoreCommand::Transaction(vec![mutation]);
+        let mutation =
+            Mutation::set("foo", "value", Metadata::new(), Some("bar"), Some(3)).unwrap();
+        let cmd = StoreCommand::Transaction(vec![
+            MutationInner::convert(mutation, Nonce::default()).unwrap(),
+        ]);
         let packed = cmd.pack().unwrap();
         let unpacked = StoreCommand::unpack(&packed).unwrap();
         assert_eq!(cmd, unpacked);
         if let StoreCommand::Transaction(data) = unpacked
             && let Some(mutation) = data.first()
-            && let Mutation::Set { value, .. } = mutation
+            && let MutationInner::Set { cipher, .. } = mutation
         {
-            assert_eq!(value, &rmp_serde::to_vec("value").unwrap());
+            assert_eq!(cipher, &rmp_serde::to_vec("value").unwrap());
         } else {
             panic!("should be the set command");
         }

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -14,8 +14,12 @@
 
 // Declare the Raft type with the TypeConfig.
 // Reference the containing module's type config and re-export it.
+use chrono::Utc;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 pub use crate::TypeConfig;
+use crate::error::StoreError;
 
 pub type NodeId = u64;
 //pub type LogStore = crate::store::log_store::FjallLogStore<TypeConfig>;
@@ -50,3 +54,155 @@ pub type AppendEntriesResponse = openraft::raft::AppendEntriesResponse<TypeConfi
 pub type SnapshotResponse = openraft::raft::SnapshotResponse<TypeConfig>;
 pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 pub type StreamAppendResult = openraft::raft::StreamAppendResult<TypeConfig>;
+
+/// The metadata of the stored data.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Metadata {
+    /// The resource revision.
+    pub revision: u64,
+    /// The timestamp when the resource was created.
+    pub created_at: i64,
+}
+
+impl Metadata {
+    pub fn new() -> Self {
+        Self {
+            revision: 0,
+            created_at: Utc::now().timestamp(),
+        }
+    }
+
+    pub fn increment_revision(&mut self) {
+        self.revision = self.revision + 1;
+    }
+
+    /// Pack the metadata for storing in the db.
+    ///
+    /// Serialize the metadata into the bytes using the MsgPack format.
+    ///
+    /// # Returns
+    /// * `Ok(Vec<u8>)` - Bytes vector.
+    /// * `Err(StoreError)` - Error.
+    pub(crate) fn pack(&self) -> Result<Vec<u8>, StoreError> {
+        Ok(rmp_serde::to_vec(self)?)
+    }
+
+    /// Unpack the metadata stored in the storage.
+    ///
+    /// Unpack the data from the bytes array with the metadata
+    ///
+    /// # Arguments
+    /// * `value` - The binary data.
+    ///
+    /// # Returns
+    /// * `Ok(StoreDataResponse)` - Success response with the deserialized metadata.
+    /// * `Err(StoreError)` - Error if the operation fails.
+    pub(crate) fn unpack(value: &[u8]) -> Result<Self, StoreError> {
+        Ok(rmp_serde::from_slice(value)?)
+    }
+}
+
+/// The nonce used as an authentication for the data encryption.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct Nonce(u64, u64);
+
+impl Nonce {
+    pub fn new(term: u64, last_applied_index: u64) -> Self {
+        Self(term, last_applied_index)
+    }
+}
+
+/// The envelope of the storage data.
+///
+/// The data wrapped in the envelope for storing encrypted at-rest in the database.
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct StoreDataInnerEnvelope {
+    /// The resource itself.
+    #[serde(with = "serde_bytes")]
+    pub(crate) cipher: Vec<u8>,
+    /// The encryption nonce.
+    pub(crate) nonce: Nonce,
+}
+
+impl StoreDataInnerEnvelope {
+    /// Pack the data together with the associated metadata for storing in the db.
+    ///
+    /// Serialize the data into the bytes using the MsgPack format.
+    ///
+    /// # Returns
+    /// * `Ok(Vec<u8>)` - Bytes vector.
+    /// * `Err(StoreError)` - Error.
+    pub(crate) fn pack(&self) -> Result<Vec<u8>, StoreError> {
+        // TODO: data should be encrypted here before packaging
+        Ok(rmp_serde::to_vec(self)?)
+    }
+
+    /// Unpack the data stored in the storage.
+    ///
+    /// Unpack the data from the bytes array with the metadata
+    ///
+    /// # Arguments
+    /// * `value` - The binary data.
+    ///
+    /// # Returns
+    /// * `Ok(StoreDataResponse)` - Success response with the deserialized data and the associated
+    /// metadata.
+    /// * `Err(StoreError)` - Error if the operation fails.
+    pub(crate) fn unpack<T: DeserializeOwned>(value: &[u8]) -> Result<T, StoreError> {
+        let raw_envelope: StoreDataInnerEnvelope = rmp_serde::from_slice(value)?;
+        // TODO: decrypt the data.
+        let data: T = rmp_serde::from_slice(&raw_envelope.cipher)?;
+        Ok(data)
+    }
+}
+
+#[cfg(feature = "bench_internals")]
+pub fn bench_pack(payload: &[u8]) -> Result<Vec<u8>, StoreError> {
+    StoreDataInnerEnvelope {
+        cipher: payload.to_vec(),
+        nonce: Nonce::default(),
+    }
+    .pack()
+}
+
+#[cfg(feature = "bench_internals")]
+pub fn bench_unpack(payload: &[u8]) -> Result<StoreDataEnvelope<String>, StoreError> {
+    StoreDataInnerEnvelope::unpack(payload)
+}
+
+/// The store data object with the associated metadata.
+///
+/// An envelope for transferring the store data with the associated metadata unencrypted over the wire.
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct StoreDataEnvelope<T> {
+    /// The resource metadata.
+    pub metadata: Metadata,
+    /// The resource itself.
+    //#[serde(with = "serde_bytes")]
+    pub data: T,
+}
+
+impl From<&str> for StoreDataEnvelope<String> {
+    fn from(value: &str) -> Self {
+        Self {
+            metadata: Metadata::new(),
+            data: value.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inner_serde() {
+        let data = StoreDataInnerEnvelope {
+            cipher: rmp_serde::to_vec("foo").unwrap(),
+            nonce: Nonce::default(),
+        };
+        let packed = data.pack().unwrap();
+        let unpacked = StoreDataInnerEnvelope::unpack::<String>(&packed).unwrap();
+        assert_eq!("foo", unpacked);
+    }
+}

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -38,6 +38,7 @@ use openstack_keystone_distributed_storage::network::load_tls_client_config;
 use openstack_keystone_distributed_storage::protobuf as pb;
 use openstack_keystone_distributed_storage::protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient;
 use openstack_keystone_distributed_storage::store_command::*;
+use openstack_keystone_distributed_storage::{Metadata, StoreDataEnvelope};
 
 /// Set up a cluster of 3 nodes.
 /// Write to it and read from it.
@@ -197,11 +198,16 @@ async fn test_cluster_inner() -> Result<()> {
         // the cluster
         instance1
             .storage
-            .set_value("foo", "bar", None::<String>)
+            .set_value("foo", StoreDataEnvelope::from("bar"), None::<String>, None)
             .await?;
         instance2
             .storage
-            .set_value("foo1", "bar1", Some("another_keyspace"))
+            .set_value(
+                "foo1",
+                StoreDataEnvelope::from("bar1"),
+                Some("another_keyspace"),
+                None,
+            )
             .await?;
         //    // --- Wait for a while to let the replication get done.
         TypeConfig::sleep(Duration::from_millis(1_000)).await;
@@ -211,17 +217,23 @@ async fn test_cluster_inner() -> Result<()> {
     {
         for instance in &instances {
             println!("=== read `foo` on node {}", instance.node_id);
-            let got: Option<String> = instance.storage.get_by_key("foo", None::<String>).await?;
-            assert_eq!(Some("bar".to_string()), got);
+            let got: StoreDataEnvelope<String> = instance
+                .storage
+                .get_by_key("foo", None::<String>)
+                .await?
+                .expect("must present");
+            println!("the data is {:?}", got);
+            assert_eq!("bar", got.data);
 
-            let got: Option<String> = instance.storage.get_by_key("foo1", None::<String>).await?;
+            let got: Option<StoreDataEnvelope<String>> =
+                instance.storage.get_by_key("foo1", None::<String>).await?;
             assert!(got.is_none());
 
-            let got: Option<String> = instance
+            let got: Option<StoreDataEnvelope<String>> = instance
                 .storage
                 .get_by_key("foo1", Some("another_keyspace"))
                 .await?;
-            assert_eq!(Some("bar1".to_string()), got);
+            assert_eq!("bar1", got.unwrap().data);
         }
     }
 
@@ -238,25 +250,34 @@ async fn test_cluster_inner() -> Result<()> {
         for instance in &instances {
             println!("=== read `foo` on node {}", instance.node_id);
 
-            let got: Option<String> = instance.storage.get_by_key("foo", None::<String>).await?;
+            let got: Option<StoreDataEnvelope<String>> =
+                instance.storage.get_by_key("foo", None::<String>).await?;
             assert!(got.is_none());
 
-            let got: Option<String> = instance
+            let got: Option<StoreDataEnvelope<String>> = instance
                 .storage
                 .get_by_key("foo1", Some("another_keyspace"))
                 .await?;
-            assert_eq!(Some("bar1".to_string()), got);
+            assert_eq!("bar1", got.unwrap().data);
         }
     }
 
     println!("=== Transaction test");
 
     let mutations = vec![
-        Mutation::set("new_foo", "new_val", None::<&str>)?,
-        Mutation::set("new_foo2", "new_val2", None::<&str>)?,
+        Mutation::set("new_foo", "new_val", Metadata::new(), None::<&str>, Some(1))?,
+        Mutation::set(
+            "new_foo2",
+            "new_val2",
+            Metadata::new(),
+            None::<&str>,
+            Some(1),
+        )?,
         Mutation::remove("foo1", Some("another_keyspace"))?,
     ];
     instance1.storage.transaction(mutations).await?;
+    // wait for the log to be applied
+    TypeConfig::sleep(Duration::from_millis(10)).await;
     assert_eq!(
         "new_val",
         instance1
@@ -264,6 +285,7 @@ async fn test_cluster_inner() -> Result<()> {
             .get_by_key::<String, &str, &str>("new_foo", None)
             .await?
             .expect("data should be there")
+            .data
     );
     assert_eq!(
         "new_val2",
@@ -272,11 +294,12 @@ async fn test_cluster_inner() -> Result<()> {
             .get_by_key::<String, &str, &str>("new_foo2", None)
             .await?
             .expect("data should be there")
+            .data
     );
     assert!(
         instance1
             .storage
-            .get_by_key::<String, &str, &str>("foo1", Some("another_keyspace"))
+            .get_by_key::<StoreDataEnvelope<String>, &str, &str>("foo1", Some("another_keyspace"))
             .await?
             .is_none()
     );

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -17,15 +17,15 @@ use chrono::Utc;
 use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
 use openstack_keystone_core::keystone::ServiceState;
-use openstack_keystone_distributed_storage::app::Storage;
+use openstack_keystone_distributed_storage::{Metadata, StoreDataEnvelope, app::Storage};
 
 use crate::{
     WebauthnError,
     types::{WebauthnApi, WebauthnCredential},
 };
 
-static DATA_KEYSPACE: &str = "webauthn:data";
-static META_KEYSPACE: &str = "webauthn:meta";
+static DATA_KEYSPACE: &str = "data";
+//static META_KEYSPACE: &str = "meta";
 static KEY_CURRENT_STATE: &str = "webauthn:state:current";
 
 /// Raft driver for the WebAuthN extension.
@@ -48,18 +48,26 @@ impl RaftDriver {
         storage: &Storage,
     ) -> Result<String, WebauthnError> {
         let res = match storage
-            .get_by_key(KEY_CURRENT_STATE, Some(META_KEYSPACE))
+            .get_by_key(KEY_CURRENT_STATE, Some(DATA_KEYSPACE))
             .await?
         {
             Some(val) => {
                 // Use the current value
-                val
+                val.data
             }
             None => {
                 // Write the new value and use the result as the name
                 let ks_name = self.generate_state_keyspace_name(&storage);
                 storage
-                    .set_value(KEY_CURRENT_STATE, &ks_name, Some(META_KEYSPACE))
+                    .set_value(
+                        KEY_CURRENT_STATE,
+                        StoreDataEnvelope {
+                            metadata: Metadata::new(),
+                            data: ks_name.clone(),
+                        },
+                        Some(DATA_KEYSPACE),
+                        None,
+                    )
                     .await?;
                 ks_name
             }
@@ -109,8 +117,12 @@ impl WebauthnApi for RaftDriver {
             .ok_or(WebauthnError::RaftNotAvailable)?;
         raft.set_value(
             self.get_cred_key_name(&credential.user_id, &credential.credential_id),
-            &credential,
+            StoreDataEnvelope {
+                metadata: Metadata::new(),
+                data: credential.clone(),
+            },
             Some(DATA_KEYSPACE),
+            None,
         )
         .await?;
         Ok(credential.clone())
@@ -133,7 +145,8 @@ impl WebauthnApi for RaftDriver {
                 self.get_cred_key_name(user_id, credential_id),
                 Some(DATA_KEYSPACE),
             )
-            .await?)
+            .await?
+            .map(|x| x.data))
     }
 
     /// Delete credential for the user.
@@ -210,7 +223,8 @@ impl WebauthnApi for RaftDriver {
                 self.get_user_cred_auth_state_key_name(user_id),
                 Some(self.get_current_state_keyspace_name(&raft).await?),
             )
-            .await?)
+            .await?
+            .map(|x| x.data))
     }
 
     /// Get webauthn credential registration state.
@@ -229,7 +243,8 @@ impl WebauthnApi for RaftDriver {
                 self.get_user_cred_registration_state_key_name(user_id),
                 Some(self.get_current_state_keyspace_name(&raft).await?),
             )
-            .await?)
+            .await?
+            .map(|x| x.data))
     }
 
     /// List user webauthn credentials.
@@ -247,7 +262,7 @@ impl WebauthnApi for RaftDriver {
             .prefix(self.get_user_cred_list_prefix(user_id), Some(DATA_KEYSPACE))
             .await?
             .into_iter()
-            .map(|(_, v)| v)
+            .map(|(_, v)| v.data)
             .collect())
     }
 
@@ -265,8 +280,12 @@ impl WebauthnApi for RaftDriver {
             .ok_or(WebauthnError::RaftNotAvailable)?;
         raft.set_value(
             self.get_user_cred_auth_state_key_name(user_id),
-            &auth_state,
+            StoreDataEnvelope {
+                metadata: Metadata::new(),
+                data: auth_state,
+            },
             Some(self.get_current_state_keyspace_name(&raft).await?),
+            None,
         )
         .await?;
         Ok(())
@@ -286,8 +305,12 @@ impl WebauthnApi for RaftDriver {
             .ok_or(WebauthnError::RaftNotAvailable)?;
         raft.set_value(
             self.get_user_cred_registration_state_key_name(user_id),
-            &reg_state,
+            StoreDataEnvelope {
+                metadata: Metadata::new(),
+                data: reg_state,
+            },
             Some(self.get_current_state_keyspace_name(&raft).await?),
+            None,
         )
         .await?;
         Ok(())
@@ -306,12 +329,29 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.set_value(
-            self.get_cred_key_name(user_id, credential_id),
-            &credential,
-            Some(DATA_KEYSPACE),
-        )
-        .await?;
-        Ok(credential.clone())
+        if let Some(curr) = raft
+            .get_by_key::<WebauthnCredential, String, &str>(
+                self.get_cred_key_name(user_id, credential_id),
+                Some(DATA_KEYSPACE),
+            )
+            .await?
+        {
+            let mut new_meta = curr.metadata.clone();
+            new_meta.increment_revision();
+            let curr_revision = curr.metadata.revision;
+            raft.set_value(
+                self.get_cred_key_name(user_id, credential_id),
+                StoreDataEnvelope {
+                    metadata: new_meta,
+                    data: credential,
+                },
+                Some(DATA_KEYSPACE),
+                Some(curr_revision),
+            )
+            .await?;
+            Ok(credential.clone())
+        } else {
+            return Err(WebauthnError::CredentialNotFound(credential_id.to_string()));
+        }
     }
 }


### PR DESCRIPTION
When we write/read to the DS we may need metadata (creation time,
revision, etc). This is also necessary for the data encryption. It also
allows to implement checks for modification operations (expect revision
number).
