### PR TITLE
feat: Add SetIndex/RemoveIndex storage commands

### DIFF
--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -235,6 +235,9 @@ fn bench_command_serde(c: &mut Criterion) {
         )
         .unwrap(),
     ]);
+    let delete_index_cmd = StoreCommand::Transaction(vec![
+        MutationInner::convert(Mutation::remove_index("foo").unwrap(), Nonce::default()).unwrap(),
+    ]);
     let set_cmd = StoreCommand::Transaction(vec![
         MutationInner::convert(
             Mutation::set("foo", "bar", Metadata::new(), Some("bar"), None).unwrap(),
@@ -242,33 +245,30 @@ fn bench_command_serde(c: &mut Criterion) {
         )
         .unwrap(),
     ]);
-    let delete_packed = delete_cmd.pack().unwrap();
-    let set_packed = set_cmd.pack().unwrap();
+    let set_index_cmd = StoreCommand::Transaction(vec![
+        MutationInner::convert(Mutation::set_index("foo").unwrap(), Nonce::default()).unwrap(),
+    ]);
     let mut group = c.benchmark_group("Command_Serde");
-    group.bench_with_input(BenchmarkId::new("serde", "set_pack"), &set_cmd, |b, cmd| {
-        b.iter(|| cmd.pack());
-    });
-    group.bench_with_input(
-        BenchmarkId::new("serde", "delete_pack"),
-        &delete_cmd,
-        |b, cmd| {
+    for (cmd, name) in [
+        (&set_cmd, "set"),
+        (&set_index_cmd, "set_index"),
+        (&delete_cmd, "delete"),
+        (&delete_index_cmd, "delete_index"),
+    ] {
+        group.bench_with_input(BenchmarkId::new("pack", name), &cmd, |b, cmd| {
             b.iter(|| cmd.pack());
-        },
-    );
-    group.bench_with_input(
-        BenchmarkId::new("serde", "set_unpack"),
-        &set_packed,
-        |b, payload| {
-            b.iter(|| StoreCommand::unpack(black_box(payload)));
-        },
-    );
-    group.bench_with_input(
-        BenchmarkId::new("serde", "delete_unpack"),
-        &delete_packed,
-        |b, payload| {
-            b.iter(|| StoreCommand::unpack(black_box(payload)));
-        },
-    );
+        });
+    }
+    for (data, name) in [
+        (set_cmd.pack().unwrap(), "set"),
+        (set_index_cmd.pack().unwrap(), "set_index"),
+        (delete_cmd.pack().unwrap(), "delete"),
+        (delete_index_cmd.pack().unwrap(), "delete_index"),
+    ] {
+        group.bench_with_input(BenchmarkId::new("unpack", name), &data, |b, data| {
+            b.iter(|| StoreCommand::unpack(black_box(data)));
+        });
+    }
     group.finish();
 }
 

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -14,14 +14,17 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
+use eyre::eyre;
 use openraft::Config;
 use openraft::async_runtime::WatchReceiver;
 use openraft::errors::{ForwardToLeader, RaftError};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::sync::watch;
+use tonic::Code;
 use tonic::service::Routes;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tracing::debug;
 
 use openstack_keystone_config::DistributedStorageConfiguration;
 
@@ -31,12 +34,20 @@ use crate::grpc::raft_service::RaftServiceImpl;
 use crate::grpc::storage_service::StorageServiceImpl;
 use crate::network::NetworkManager;
 use crate::network::init_tls_watcher;
+use crate::pb::api::Response;
 use crate::pb::raft::cluster_admin_service_server::ClusterAdminServiceServer;
 use crate::pb::raft::raft_service_server::RaftServiceServer;
 use crate::protobuf::api::storage_service_client::StorageServiceClient;
 use crate::protobuf::api::storage_service_server::StorageServiceServer;
 use crate::store_command::*;
 use crate::types::*;
+
+/// gRPC metadata header used to communicate the leader's endpoint to clients.
+///
+/// When a non-leader node receives a write request, it returns `Status::unavailable`
+/// with this header set to the leader's address, so clients can retry against the leader.
+pub const LEADER_ENDPOINT_HEADER: &str = "x-openraft-leader-endpoint";
+pub const LEADER_ID_HEADER: &str = "x-openraft-leader-id";
 
 /// Initialize storage services backed by the raft.
 pub async fn init_storage(
@@ -79,21 +90,15 @@ pub async fn init_storage(
 
 /// Build a tonic `Server` instance for the raft instance.
 pub async fn get_app_server(storage: &Storage) -> Result<Routes, StoreError> {
-    //// The app service uses the default limit since it's user-facing.
-
     let raft_svc_impl = RaftServiceImpl::new(storage.raft.clone());
     let cluster_admin_svc_impl = ClusterAdminServiceImpl::new(storage.raft.clone());
     let storage_svc_impl = StorageServiceImpl::new(storage.raft.clone());
 
-    let raft_service = RaftServiceServer::new(raft_svc_impl);
-    let cluster_admin_service = ClusterAdminServiceServer::new(cluster_admin_svc_impl);
-    let storage_service = StorageServiceServer::new(storage_svc_impl);
-
     let mut router = Routes::builder();
     router
-        .add_service(raft_service)
-        .add_service(cluster_admin_service)
-        .add_service(storage_service);
+        .add_service(RaftServiceServer::new(raft_svc_impl))
+        .add_service(ClusterAdminServiceServer::new(cluster_admin_svc_impl))
+        .add_service(StorageServiceServer::new(storage_svc_impl));
 
     Ok(router.routes())
 }
@@ -111,77 +116,28 @@ pub struct Storage {
 }
 
 impl Storage {
-    /// Mutation transaction
+    /// Checks whether a given key is present in the keyspace of the distributed store.
     ///
     /// # Arguments
-    /// * `mutations` - List of mutations that must be applied as a single transaction.
-    ///
-    /// # Returns
-    /// * `Ok(Response)` - Success response after the value is deleted
-    /// * `Err(Status)` - Error status if the set operation fails
-    pub async fn transaction(&self, mutations: Vec<Mutation>) -> Result<(), StoreError> {
-        let metrics = self.raft.metrics().borrow_watched().clone();
-        let nonce = Nonce::new(metrics.current_term, metrics.last_log_index.unwrap_or(1));
-        let request = StoreCommand::Transaction(
-            mutations
-                .into_iter()
-                .map(|x| MutationInner::convert(x, nonce.clone()))
-                .collect::<Result<Vec<_>, _>>()?,
-        );
-        let payload = crate::pb::api::CommandRequest::try_from(request)?;
-        match self.raft.client_write(payload.clone()).await {
-            Ok(_) => {}
-            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
-                leader_id: Some(leader_id),
-                leader_node: Some(leader_node),
-            }))) => {
-                let channel = self.get_or_create_channel(leader_id, leader_node.rpc_addr)?;
-
-                let mut client = StorageServiceClient::new(channel);
-                client.command(payload).await?;
-            }
-            Err(other) => {
-                return Err(other)?;
-            }
-        };
-        Ok(())
-    }
-
-    /// Deletes a value for a given key in the distributed store.
-    ///
-    /// # Arguments
-    /// * `key` - The key.
+    /// * `key` - Contains the key to retrieve.
     /// * `keyspace` - Optional keyspace name.
     ///
     /// # Returns
-    /// * `Ok(Response)` - Success response after the value is deleted
-    /// * `Err(Status)` - Error status if the set operation fails
-    pub async fn remove<K, S>(&self, key: K, keyspace: Option<S>) -> Result<(), StoreError>
+    /// * `Ok(bool)` - Success response
+    /// * `Err(Status)` - Error status if the get operation fails
+    pub async fn contains_key<K, S>(&self, key: K, keyspace: Option<S>) -> Result<bool, StoreError>
     where
-        K: Into<Vec<u8>>,
-        S: Into<String>,
+        K: AsRef<[u8]>,
+        S: AsRef<str>,
     {
-        let request = StoreCommand::Transaction(vec![MutationInner::convert(
-            Mutation::remove(key, keyspace)?,
-            Nonce::default(),
-        )?]);
-        let payload = crate::pb::api::CommandRequest::try_from(request)?;
-        match self.raft.client_write(payload.clone()).await {
-            Ok(_) => {}
-            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
-                leader_id: Some(leader_id),
-                leader_node: Some(leader_node),
-            }))) => {
-                let channel = self.get_or_create_channel(leader_id, leader_node.rpc_addr)?;
+        // wait for the node to apply the latest state
+        // self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await?;
 
-                let mut client = StorageServiceClient::new(channel);
-                client.command(payload).await?;
-            }
-            Err(other) => {
-                return Err(other)?;
-            }
+        let ks = match keyspace {
+            None => self.state_machine_store.data(),
+            Some(name) => &self.state_machine_store.keyspace(name)?,
         };
-        Ok(())
+        Ok(ks.contains_key(&key)?)
     }
 
     /// Gets a value for a given key from the distributed store.
@@ -210,7 +166,7 @@ impl Storage {
             None => self.state_machine_store.data(),
             Some(name) => &self.state_machine_store.keyspace(name)?,
         };
-        // NOTE: running lookups in separate tasks make huge negative performance impact (+1000%).
+        // NOTE: running lookup in separate tasks makes huge negative performance impact (+1000%).
         if let Some(data) = ks
             .get(&key)?
             .map(|x| StoreDataInnerEnvelope::unpack(x.as_ref()))
@@ -285,6 +241,74 @@ impl Storage {
             .collect()
     }
 
+    /// List index keys the prefix.
+    ///
+    /// Return keys matching the specified prefix in the index keyspace.
+    ///
+    /// # Arguments
+    /// * `prefix` - The prefix to query.
+    ///
+    /// # Returns
+    /// * `Ok(Vec<String>)` - Success response containing the value as bytes
+    /// * `Err(Status)` - Error status if the operation fails
+    pub async fn prefix_index<K>(&self, prefix: K) -> Result<Vec<String>, StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        // wait for the node to apply the latest state
+        // self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await?;
+
+        self.state_machine_store
+            .index()
+            .prefix(&prefix)
+            .map(|item| {
+                let key = item.key()?;
+                let k = String::from_utf8(key.to_vec())?;
+                Ok(k)
+            })
+            .collect()
+    }
+
+    /// Deletes a value for a given key in the distributed store.
+    ///
+    /// # Arguments
+    /// * `key` - The key.
+    /// * `keyspace` - Optional keyspace name.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - Success response after the value is deleted
+    /// * `Err(Status)` - Error status if the set operation fails
+    pub async fn remove<K, S>(&self, key: K, keyspace: Option<S>) -> Result<Response, StoreError>
+    where
+        K: Into<Vec<u8>>,
+        S: Into<String>,
+    {
+        let request = StoreCommand::Transaction(vec![MutationInner::convert(
+            Mutation::remove(key, keyspace)?,
+            Nonce::default(),
+        )?]);
+        let payload = crate::pb::api::CommandRequest::try_from(request)?;
+        self.write_command_to_storage(payload).await
+    }
+
+    /// Deletes index key in the distributed store.
+    ///
+    /// # Arguments
+    /// * `key` - The key.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - Success response after the value is deleted
+    /// * `Err(Status)` - Error status if the set operation fails
+    pub async fn remove_index<K>(&self, key: K) -> Result<Response, StoreError>
+    where
+        K: Into<Vec<u8>>,
+    {
+        let request =
+            StoreCommand::Transaction(vec![MutationInner::RemoveIndex { key: key.into() }]);
+        let payload = crate::pb::api::CommandRequest::try_from(request)?;
+        self.write_command_to_storage(payload).await
+    }
+
     /// Sets a value for a given key in the distributed store.
     ///
     /// # Arguments
@@ -301,7 +325,7 @@ impl Storage {
         value: StoreDataEnvelope<V>,
         keyspace: Option<S>,
         expected_revision: Option<u64>,
-    ) -> Result<(), StoreError>
+    ) -> Result<Response, StoreError>
     where
         K: Into<String>,
         V: Serialize,
@@ -316,22 +340,49 @@ impl Storage {
         )?]);
 
         let payload = crate::pb::api::CommandRequest::try_from(request)?;
-        match self.raft.client_write(payload.clone()).await {
-            Ok(_) => {}
-            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
-                leader_id: Some(leader_id),
-                leader_node: Some(leader_node),
-            }))) => {
-                let channel = self.get_or_create_channel(leader_id, leader_node.rpc_addr)?;
+        self.write_command_to_storage(payload).await
+    }
 
-                let mut client = StorageServiceClient::new(channel);
-                client.command(payload).await?;
-            }
-            Err(other) => {
-                return Err(other)?;
-            }
-        };
-        Ok(())
+    /// Sets an index key in the distributed store.
+    ///
+    /// Sets the key with an empty value in the index keyspace of the storage.
+    ///
+    /// # Arguments
+    /// * `key` - The key.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - Success response after the value is set
+    /// * `Err(StoreError)` - Error status if the set operation fails
+    pub async fn set_index_key<K>(&self, key: K) -> Result<Response, StoreError>
+    where
+        K: Into<String>,
+    {
+        let key: String = key.into();
+        let request = StoreCommand::Transaction(vec![MutationInner::SetIndex { key: key.into() }]);
+
+        let payload = crate::pb::api::CommandRequest::try_from(request)?;
+        self.write_command_to_storage(payload).await
+    }
+
+    /// Mutation transaction
+    ///
+    /// # Arguments
+    /// * `mutations` - List of mutations that must be applied as a single transaction.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - Success response after the value is deleted
+    /// * `Err(Status)` - Error status if the set operation fails
+    pub async fn transaction(&self, mutations: Vec<Mutation>) -> Result<Response, StoreError> {
+        let metrics = self.raft.metrics().borrow_watched().clone();
+        let nonce = Nonce::new(metrics.current_term, metrics.last_log_index.unwrap_or(1));
+        let request = StoreCommand::Transaction(
+            mutations
+                .into_iter()
+                .map(|x| MutationInner::convert(x, nonce.clone()))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        let payload = crate::pb::api::CommandRequest::try_from(request)?;
+        self.write_command_to_storage(payload).await
     }
 
     /// Get the last log index processed by the node.
@@ -366,5 +417,107 @@ impl Storage {
         // 3. Cache it
         self.connection_pool.insert(target, channel.clone());
         Ok(channel)
+    }
+
+    /// Try to commit the command to the raft cluster.
+    ///
+    /// Attempt to commit command to the current node forwarding the request with a retry mechanism
+    /// to the leader node.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - A command to apply to the cluster.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - A command response.
+    /// * `Err(StoreError)` - An error if the operation fails.
+    async fn write_command_to_storage(
+        &self,
+        command: crate::pb::api::CommandRequest,
+    ) -> Result<Response, StoreError> {
+        match self.raft.client_write(command.clone()).await {
+            Ok(rsp) => Ok(rsp.data),
+            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
+                leader_id: Some(leader_id),
+                leader_node: Some(leader_node),
+            }))) => {
+                self.command_with_forwarding(command, leader_id, leader_node.rpc_addr)
+                    .await
+            }
+            Err(other) => {
+                return Err(other)?;
+            }
+        }
+    }
+
+    /// Generic retry loop: on `Unavailable` with leader metadata, switch endpoint and retry.
+    ///
+    /// Apply the command to the cluster node by the ID and ADDR forwarding it to the "new" leader
+    /// if the switch happens and a generic retry mechanism.
+    ///
+    /// # Arguments
+    /// * `command` - A command to apply.
+    /// * `node_id` - The cluster node id to connect to.
+    /// * `node_addr` - The cluster node address.
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - The command response.
+    /// * `Err(StoreError)` - The error if operation failed.
+    async fn command_with_forwarding(
+        &self,
+        command: crate::pb::api::CommandRequest,
+        node_id: u64,
+        node_addr: String,
+    ) -> Result<Response, StoreError> {
+        let max_retries = 3;
+
+        let mut node_addr = node_addr.clone();
+        let mut node_id = node_id.clone();
+
+        for _attempt in 0..=max_retries {
+            // Establish a gRPC channel to the given node
+            let channel = self.get_or_create_channel(node_id, node_addr)?;
+            // Init the client
+            let mut client = StorageServiceClient::new(channel);
+            // Try to execute the command
+            let result = client.command(command.clone()).await;
+
+            match result {
+                Ok(resp) => return Ok(resp.into_inner().into()),
+                Err(status) if status.code() == Code::Unavailable => {
+                    // Extract leader endpoint from gRPC metadata
+                    // TODO: teach the gRPC app to start exposing the headers.
+                    let leader_addr = status
+                        .metadata()
+                        .get(LEADER_ENDPOINT_HEADER)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    let leader_id: Option<u64> = status
+                        .metadata()
+                        .get(LEADER_ID_HEADER)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.parse())
+                        .transpose()?;
+
+                    if let (Some(addr), Some(id)) = (leader_addr, leader_id) {
+                        debug!("forwarding request to leader at {}", addr);
+                        node_addr = addr;
+                        node_id = id;
+                        continue;
+                    }
+
+                    return Err(eyre!(
+                        "Unavailable but no leader endpoint in metadata: {}",
+                        status
+                    )
+                    .into());
+                }
+                Err(status) => {
+                    return Err(eyre!("RPC failed: {}", status).into());
+                }
+            }
+        }
+
+        return Err(eyre!("max retries exceeded").into());
     }
 }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -132,6 +132,13 @@ pub enum StoreError {
         source: rmp_serde::encode::Error,
     },
 
+    /// Parse int error.
+    #[error(transparent)]
+    ParseInt {
+        #[from]
+        source: std::num::ParseIntError,
+    },
+
     #[error(transparent)]
     Storage {
         #[from]

--- a/crates/storage/src/grpc/storage_service.rs
+++ b/crates/storage/src/grpc/storage_service.rs
@@ -64,12 +64,10 @@ impl StorageService for StorageServiceImpl {
     ) -> Result<Response<PbResponse>, Status> {
         let req = request.into_inner();
 
-        let res = self
-            .raft_node
-            .client_write(req)
-            //.set_value(req.key.clone(), req.value, req.keyspace)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to write command to store: {}", e)))?;
+        let res =
+            self.raft_node.client_write(req).await.map_err(|e| {
+                Status::internal(format!("Failed to write command to store: {}", e))
+            })?;
 
         //debug!("Successfully set value for key: {}", req.key);
         Ok(Response::new(res.data))

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -95,6 +95,11 @@ impl FjallStateMachine {
         &self.data
     }
 
+    /// Get the index `keyspace` handle.
+    pub fn index(&self) -> &Keyspace {
+        &self.index
+    }
+
     /// Get the metadata `keyspace` handle.
     pub fn meta(&self) -> &Keyspace {
         &self.meta
@@ -390,6 +395,9 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                     batch.remove(ks, key.clone());
                                     batch.remove(&self.meta, key.clone());
                                 }
+                                MutationInner::RemoveIndex { key } => {
+                                    batch.remove(&self.index, key.clone());
+                                }
                                 MutationInner::Set {
                                     key,
                                     keyspace,
@@ -436,6 +444,9 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                     .pack()?;
                                     batch.insert(ks, key.clone(), inner_data);
                                     batch.insert(&self.meta, key.clone(), metadata.pack()?);
+                                }
+                                MutationInner::SetIndex { key } => {
+                                    batch.insert(&self.index, key, vec![]);
                                 }
                             }
                         }

--- a/crates/storage/src/store_command.rs
+++ b/crates/storage/src/store_command.rs
@@ -41,6 +41,12 @@ pub enum MutationInner {
         keyspace: String,
     },
 
+    /// Delete the entry from the index store.
+    RemoveIndex {
+        /// The Key to delete.
+        key: Vec<u8>,
+    },
+
     /// Set the value for the key in the store.
     Set {
         /// The value to set.
@@ -62,6 +68,12 @@ pub enum MutationInner {
         /// Nonce.
         nonce: Nonce,
     },
+
+    /// Set the key in the index keyspace.
+    SetIndex {
+        /// The key to set.
+        key: Vec<u8>,
+    },
 }
 
 impl MutationInner {
@@ -72,6 +84,7 @@ impl MutationInner {
     pub fn convert(value: Mutation, nonce: Nonce) -> Result<MutationInner, StoreError> {
         Ok(match value {
             Mutation::Remove { key, keyspace } => MutationInner::Remove { key, keyspace },
+            Mutation::RemoveIndex { key } => MutationInner::RemoveIndex { key },
             Mutation::Set {
                 key,
                 keyspace,
@@ -87,6 +100,7 @@ impl MutationInner {
                 nonce,
                 expected_revision,
             },
+            Mutation::SetIndex { key } => MutationInner::SetIndex { key },
         })
     }
 }
@@ -101,6 +115,12 @@ pub enum Mutation {
 
         /// The `keyspace` of the key.
         keyspace: String,
+    },
+
+    /// Delete the entry from the store.
+    RemoveIndex {
+        /// The Key to delete.
+        key: Vec<u8>,
     },
 
     /// Set the value for the key in the store.
@@ -121,6 +141,12 @@ pub enum Mutation {
         #[serde(with = "serde_bytes")]
         value: Vec<u8>,
     },
+
+    /// Set the value for the key in the store.
+    SetIndex {
+        /// The key to set.
+        key: Vec<u8>,
+    },
 }
 
 impl Mutation {
@@ -133,6 +159,13 @@ impl Mutation {
             key: key.into(),
             keyspace: keyspace.map(Into::into).unwrap_or("data".into()),
         })
+    }
+
+    pub fn remove_index<K>(key: K) -> Result<Self, StoreError>
+    where
+        K: Into<Vec<u8>>,
+    {
+        Ok(Self::RemoveIndex { key: key.into() })
     }
 
     pub fn set<K, V, S>(
@@ -154,6 +187,13 @@ impl Mutation {
             metadata: metadata,
             expected_revision,
         })
+    }
+
+    pub fn set_index<K>(key: K) -> Result<Self, StoreError>
+    where
+        K: Into<Vec<u8>>,
+    {
+        Ok(Self::SetIndex { key: key.into() })
     }
 }
 
@@ -201,6 +241,18 @@ mod tests {
     }
 
     #[test]
+    fn test_delete_index_command() {
+        let mutation = Mutation::remove_index("foo").unwrap();
+        let cmd = StoreCommand::Transaction(vec![
+            MutationInner::convert(mutation, Nonce::default()).unwrap(),
+        ]);
+
+        let packed = cmd.pack().unwrap();
+        let unpacked = StoreCommand::unpack(&packed).unwrap();
+        assert_eq!(cmd, unpacked);
+    }
+
+    #[test]
     fn test_set_command() {
         let mutation =
             Mutation::set("foo", "value", Metadata::new(), Some("bar"), Some(3)).unwrap();
@@ -217,6 +269,25 @@ mod tests {
             assert_eq!(cipher, &rmp_serde::to_vec("value").unwrap());
         } else {
             panic!("should be the set command");
+        }
+    }
+
+    #[test]
+    fn test_set_index_command() {
+        let mutation = Mutation::set_index("foo").unwrap();
+        let cmd = StoreCommand::Transaction(vec![
+            MutationInner::convert(mutation, Nonce::default()).unwrap(),
+        ]);
+        let packed = cmd.pack().unwrap();
+        let unpacked = StoreCommand::unpack(&packed).unwrap();
+        assert_eq!(cmd, unpacked);
+        if let StoreCommand::Transaction(data) = unpacked
+            && let Some(mutation) = data.first()
+            && let MutationInner::SetIndex { key } = mutation
+        {
+            assert_eq!("foo".as_bytes(), key);
+        } else {
+            panic!("should be the set_index command");
         }
     }
 }

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -209,6 +209,9 @@ async fn test_cluster_inner() -> Result<()> {
                 None,
             )
             .await?;
+        instance3.storage.set_index_key("idx:foo:1").await?;
+        instance3.storage.set_index_key("idx:foo:2").await?;
+        instance3.storage.set_index_key("idx:foo:3").await?;
         //    // --- Wait for a while to let the replication get done.
         TypeConfig::sleep(Duration::from_millis(1_000)).await;
     }
@@ -224,22 +227,30 @@ async fn test_cluster_inner() -> Result<()> {
                 .expect("must present");
             println!("the data is {:?}", got);
             assert_eq!("bar", got.data);
+            assert!(instance.storage.contains_key("foo", None::<&str>).await?);
 
             let got: Option<StoreDataEnvelope<String>> =
                 instance.storage.get_by_key("foo1", None::<String>).await?;
             assert!(got.is_none());
+            assert!(!instance.storage.contains_key("foo1", None::<&str>).await?);
 
             let got: Option<StoreDataEnvelope<String>> = instance
                 .storage
                 .get_by_key("foo1", Some("another_keyspace"))
                 .await?;
             assert_eq!("bar1", got.unwrap().data);
+            let indexes = instance.storage.prefix_index("idx:foo").await?;
+            assert!(indexes.contains(&"idx:foo:1".to_string()));
+            assert!(indexes.contains(&"idx:foo:2".to_string()));
+            assert!(indexes.contains(&"idx:foo:3".to_string()));
+            assert_eq!(indexes.len(), 3);
         }
     }
 
     println!("=== delete `foo=bar`");
     {
         instance3.storage.remove("foo", None::<String>).await?;
+        instance2.storage.remove_index("idx:foo:1").await?;
 
         // --- Wait for a while to let the replication get done.
         TypeConfig::sleep(Duration::from_millis(1_000)).await;
@@ -259,6 +270,10 @@ async fn test_cluster_inner() -> Result<()> {
                 .get_by_key("foo1", Some("another_keyspace"))
                 .await?;
             assert_eq!("bar1", got.unwrap().data);
+            let indexes = instance.storage.prefix_index("idx:foo").await?;
+            assert!(indexes.contains(&"idx:foo:2".to_string()));
+            assert!(indexes.contains(&"idx:foo:3".to_string()));
+            assert_eq!(indexes.len(), 2);
         }
     }
 


### PR DESCRIPTION
For custom indexes in the KV database there is no associated data (the
key itself is the index). Also there is no need to keep metadata for
them and prefix searching looks much lighter compared to the regular
data requests. As such add 2 new command types, corresponding interface
into the storage interface and do internal de-duplication of the request
forwarding.
