### PR TITLE
feat: Add skeleton for the spiffe mTLS integration

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -443,4 +443,4 @@ jobs:
 
       - name: Dump keystone-rs logs
         if: failure()
-        run: kubectl logs deployment/keystone-rs -c keystone
+        run: kubectl logs statefulset/keystone-rs -c keystone

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3576,7 +3576,10 @@ dependencies = [
  "color-eyre",
  "derive_builder",
  "eyre",
+ "futures-util",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "openidconnect",
  "openstack-keystone-api-types",
  "openstack-keystone-appcred-sql",
@@ -3607,8 +3610,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "spiffe",
+ "spiffe-rustls",
+ "spiffe-rustls-tokio",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tonic",
  "tower",
@@ -3760,6 +3767,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "spiffe",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5968,6 +5976,62 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spiffe"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "929880b6a86a7f4456d35482330957d6f64a6fd99fcb88302d039526e085f84a"
+dependencies = [
+ "arc-swap",
+ "base64ct",
+ "fastrand",
+ "futures",
+ "hyper-util",
+ "pkcs8",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "url",
+ "x509-parser 0.18.1",
+ "zeroize",
+]
+
+[[package]]
+name = "spiffe-rustls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaefd19f26d525058a995d7fde5bfb17d4345a86727b8ecd1860008e2986868"
+dependencies = [
+ "oid-registry 0.8.1",
+ "rustls",
+ "spiffe",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "x509-parser 0.18.1",
+]
+
+[[package]]
+name = "spiffe-rustls-tokio"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49cdf9f3b807b61ae131b6d829139333c932b376f027f6d101f04fa7265c278"
+dependencies = [
+ "rustls",
+ "spiffe",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ exclude = [
 [workspace.dependencies]
 async-trait = { version = "0.1" }
 axum = { version = "0.8", default-features = false }
+axum-server = { version = "0.8", default-features = false }
 base64 = { version = "0.22" }
 base64urlsafedata = "0.5"
 bcrypt = { version = "0.19" }
@@ -93,9 +94,11 @@ serde = { version = "1.0" }
 serde_bytes = { version = "0.11" }
 serde_json = { version = "1.0" }
 serde_urlencoded = { version = "0.7" }
+spiffe = { version = "0.14.0" }
 tempfile = { version = "3.27" }
 thiserror = { version = "2.0" }
 tokio = { version = "1.51", default-features = false }
+tokio-rustls = "0.26.4"
 tokio-util = { version = "0.7" }
 tonic = { version = "0.14" }
 tonic-prost-build = { version = "0.14" }

--- a/crates/api-types/src/v3/project.rs
+++ b/crates/api-types/src/v3/project.rs
@@ -216,7 +216,6 @@ mod tests {
     use super::*;
     #[cfg(feature = "builder")]
     use crate::error::BuilderError;
-    use serde_json::json;
 
     #[cfg(feature = "builder")]
     #[test]
@@ -248,7 +247,7 @@ mod tests {
     #[test]
     fn test_project_serialize_extra() {
         assert_eq!(
-            json!({"name": "name", "domain_id": "did", "enabled": true, "is_domain": false}),
+            serde_json::json!({"name": "name", "domain_id": "did", "enabled": true, "is_domain": false}),
             serde_json::to_value(
                 &ProjectCreateBuilder::default()
                     .name("name")
@@ -259,14 +258,14 @@ mod tests {
             .unwrap()
         );
         assert_eq!(
-            json!({"name": "name", "domain_id": "did", "enabled": true, "is_domain": false, "unknown": "bar"}),
+            serde_json::json!({"name": "name", "domain_id": "did", "enabled": true, "is_domain": false, "unknown": "bar"}),
             serde_json::to_value(
                 &ProjectCreateBuilder::default()
                     .name("name")
                     .domain_id("did")
                     .extra(std::collections::HashMap::from([(
                         "unknown".into(),
-                        json!("bar")
+                        serde_json::json!("bar")
                     )]))
                     .build()
                     .unwrap()

--- a/crates/cli-manage/src/main.rs
+++ b/crates/cli-manage/src/main.rs
@@ -59,7 +59,7 @@ pub trait PerformAction {
 #[tokio::main]
 async fn main() -> Result<(), Report> {
     let args = Args::parse();
-    let cfg = Config::new(args.config)?;
+    let cfg = Config::load_all(args.config)?;
     match args.command {
         Command::Storage(x) => x.take_action(&cfg).await?,
     }

--- a/crates/cli-manage/src/storage.rs
+++ b/crates/cli-manage/src/storage.rs
@@ -16,11 +16,13 @@
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use color_eyre::{Report, eyre::OptionExt};
-use secrecy::ExposeSecret;
-use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, Uri};
+use tonic::transport::{Channel, Uri};
 
 use openstack_keystone_config::Config;
-use openstack_keystone_distributed_storage::protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient;
+use openstack_keystone_distributed_storage::{
+    network::get_client_tls_config,
+    protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient,
+};
 
 mod demote;
 mod init;
@@ -71,55 +73,6 @@ enum StorageCommands {
     RemovePeer(RemovePeerCommand),
 }
 
-/// Prepare the [ClientTlsConfig].
-///
-/// # Parameters
-/// - `config`: The Keystone [`Config`] instance.
-///
-/// # Returns
-/// A `Result` containing the `ClientTlsConfig`.
-pub async fn get_grpc_client_tls_config(config: &Config) -> Result<ClientTlsConfig, Report> {
-    let identity = Identity::from_pem(
-        config
-            .distributed_storage
-            .as_ref()
-            .and_then(|x| x.tls_configuration.tls_cert_content.as_ref())
-            .or(config
-                .listener
-                .tls_configuration
-                .as_ref()
-                .and_then(|x| x.tls_cert_content.as_ref()))
-            .ok_or_eyre("TLS cert file missing")?
-            .expose_secret(),
-        config
-            .distributed_storage
-            .as_ref()
-            .and_then(|x| x.tls_configuration.tls_key_content.as_ref())
-            .or(config
-                .listener
-                .tls_configuration
-                .as_ref()
-                .and_then(|x| x.tls_key_content.as_ref()))
-            .ok_or_eyre("TLS key file missing")?
-            .expose_secret(),
-    );
-    let mut tls_client_config = ClientTlsConfig::new().identity(identity);
-    if let Some(cert_ca) = config
-        .distributed_storage
-        .as_ref()
-        .and_then(|x| x.tls_configuration.tls_client_ca_content.as_ref())
-        .or(config
-            .listener
-            .tls_configuration
-            .as_ref()
-            .and_then(|x| x.tls_client_ca_content.as_ref()))
-    {
-        tls_client_config =
-            tls_client_config.ca_certificate(Certificate::from_pem(cert_ca.expose_secret()));
-    };
-    Ok(tls_client_config)
-}
-
 async fn get_grpc_client(
     cfg: &Config,
     addr: Option<Uri>,
@@ -129,11 +82,11 @@ async fn get_grpc_client(
             cfg.distributed_storage
                 .as_ref()
                 .ok_or_eyre("distributed storage configuration missing")?
-                .cluster_addr
+                .node_cluster_addr
                 .clone(),
         ),
     )
-    .tls_config(get_grpc_client_tls_config(cfg).await?)?;
+    .tls_config(get_client_tls_config(cfg)?)?;
     let client = ClusterAdminServiceClient::new(ep.connect().await?);
     Ok(client)
 }

--- a/crates/cli-manage/src/storage/init.rs
+++ b/crates/cli-manage/src/storage/init.rs
@@ -33,7 +33,9 @@ pub(super) struct InitCommand {}
 impl PerformAction for InitCommand {
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         if let Some(cfg) = &config.distributed_storage {
-            if let (Some(host), Some(port)) = (cfg.cluster_addr.host(), cfg.cluster_addr.port()) {
+            if let (Some(host), Some(port)) =
+                (cfg.node_cluster_addr.host(), cfg.node_cluster_addr.port())
+            {
                 let mut client = get_grpc_client(config, None).await?;
 
                 client

--- a/crates/cli-manage/src/storage/join.rs
+++ b/crates/cli-manage/src/storage/join.rs
@@ -39,7 +39,9 @@ pub(super) struct JoinCommand {
 impl PerformAction for JoinCommand {
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         if let Some(cfg) = &config.distributed_storage {
-            if let (Some(host), Some(port)) = (cfg.cluster_addr.host(), cfg.cluster_addr.port()) {
+            if let (Some(host), Some(port)) =
+                (cfg.node_cluster_addr.host(), cfg.node_cluster_addr.port())
+            {
                 let mut client = get_grpc_client(config, Some(self.cluster_addr)).await?;
 
                 client

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,7 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 chrono = { workspace = true, features = ["now"] }
-config = { workspace = true, features = ["async", "ini"] }
+config = { workspace = true, features = ["async", "ini", "toml"] }
 derive_builder.workspace = true
 eyre.workspace = true
 http.workspace = true

--- a/crates/config/src/common.rs
+++ b/crates/config/src/common.rs
@@ -28,6 +28,7 @@ where
 {
     Ok(String::deserialize(deserializer)?
         .split(',')
+        .filter(|res| !res.is_empty())
         .map(Into::into)
         .collect())
 }
@@ -132,13 +133,21 @@ impl TlsConfiguration {
         }
         if let Some(ca) = &self.tls_client_ca_file {
             self.tls_client_ca_content = Some(
-                std::fs::read(&ca)
+                std::fs::read(ca)
                     .wrap_err_with(|| format!("reading tls ca file {:?}", ca))?
                     .into(),
             );
         }
         Ok(())
     }
+}
+
+/// Server interface type.
+#[derive(Debug, Deserialize, Clone)]
+pub enum Interface {
+    Admin,
+    Internal,
+    Public,
 }
 
 #[cfg(test)]

--- a/crates/config/src/distributed_storage.rs
+++ b/crates/config/src/distributed_storage.rs
@@ -11,19 +11,24 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use http::Uri;
 use serde::Deserialize;
 
-use crate::common::TlsConfiguration;
+use crate::common::{TlsConfiguration, csv};
 
 /// Raft cluster configuration.
 #[derive(Debug, Deserialize, Clone)]
 pub struct DistributedStorageConfiguration {
-    /// Cluster address.
+    /// The address of the node in the cluster.
     #[serde(with = "http_serde::uri")]
-    pub cluster_addr: Uri,
+    pub node_cluster_addr: Uri,
+
+    /// Address on which current node listens for peer connections.
+    #[serde(default = "default_tcp_address")]
+    pub node_listener_addr: SocketAddr,
 
     /// Node id.
     pub node_id: u64,
@@ -33,16 +38,38 @@ pub struct DistributedStorageConfiguration {
 
     /// TLS configuration for the Raft cluster communication.
     #[serde(flatten)]
-    pub tls_configuration: TlsConfiguration,
+    pub tls_configuration: RaftTlsConfiguration,
 }
 
-/// Raft cluster node.
+fn default_tcp_address() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8081)
+}
+
+///// Raft cluster node.
+//#[derive(Debug, Deserialize, Clone)]
+//pub struct ClusterNode {
+//    /// Node address.
+//    pub addr: String,
+//    /// Node ID.
+//    pub id: u64,
+//}
+
+/// Raft TLS implementation.
 #[derive(Debug, Deserialize, Clone)]
-pub struct ClusterNode {
-    /// Node address.
-    pub addr: String,
-    /// Node ID.
-    pub id: u64,
+#[serde(untagged)]
+pub enum RaftTlsConfiguration {
+    /// Spiffe mTLS - not supported yet.
+    Spiffe(SpiffeTls),
+    /// Basic (manual) TLS.
+    Tls(TlsConfiguration),
+}
+
+/// Spiffe backed mTLS for the Raft.
+#[derive(Debug, Deserialize, Clone)]
+pub struct SpiffeTls {
+    /// Trusted domains for SPIFFE verification.
+    #[serde(deserialize_with = "csv")]
+    pub trust_domains: Vec<String>,
 }
 
 #[cfg(test)]
@@ -58,7 +85,7 @@ mod tests {
     #[test]
     fn test_deser() {
         let _cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
-            "cluster_addr": "http://1.2.3.4:5678",
+            "node_cluster_addr": "http://1.2.3.4:5678",
             "node_id": 1,
             "path": "/tmp",
             "tls_cert_file": "/tmp/tls.cert",
@@ -72,7 +99,7 @@ mod tests {
         let c = Config::builder()
             .add_source(File::from_str(
                 r#"
-cluster_addr = https://localhost:8310
+node_cluster_addr = https://localhost:8310
 node_id = 1
 path = /keystone/storage
 tls_key_file = /foo
@@ -84,27 +111,25 @@ tls_client_ca_file = /baz
             .build()
             .unwrap();
         let cfg: DistributedStorageConfiguration = c.try_deserialize().unwrap();
-        assert_eq!("https://localhost:8310/", cfg.cluster_addr.to_string());
+        assert_eq!("https://localhost:8310/", cfg.node_cluster_addr.to_string());
         assert_eq!(1, cfg.node_id);
         assert_eq!("/keystone/storage", cfg.path.to_str().unwrap());
-        assert_eq!(
-            cfg.tls_configuration.tls_key_file,
-            Some(PathBuf::from("/foo"))
-        );
-        assert_eq!(
-            cfg.tls_configuration.tls_cert_file,
-            Some(PathBuf::from("/bar"))
-        );
-        assert_eq!(
-            cfg.tls_configuration.tls_client_ca_file,
-            Some(PathBuf::from("/baz"))
-        );
+        if let RaftTlsConfiguration::Tls(tls) = cfg.tls_configuration {
+            assert_eq!(tls.tls_key_file, Some(PathBuf::from("/foo")));
+            assert_eq!(tls.tls_cert_file, Some(PathBuf::from("/bar")));
+            assert_eq!(tls.tls_client_ca_file, Some(PathBuf::from("/baz")));
+        } else {
+            panic!("should be regular tls");
+        }
     }
 
     #[test]
     fn test_env() {
         temp_env::with_vars(
-            [("OS_DISTRIBUTED_STORAGE__CLUSTER_ADDR", Some("http://test/"))],
+            [(
+                "OS_DISTRIBUTED_STORAGE__NODE_CLUSTER_ADDR",
+                Some("http://test/"),
+            )],
             || {
                 let mut cfg_file = NamedTempFile::new().unwrap();
                 write!(
@@ -126,7 +151,7 @@ path = /foo
                     "http://test/",
                     cfg.distributed_storage
                         .expect("must be present")
-                        .cluster_addr
+                        .node_cluster_addr
                         .to_string()
                 );
             },

--- a/crates/config/src/interface.rs
+++ b/crates/config/src/interface.rs
@@ -1,0 +1,133 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Server interfaces
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use serde::Deserialize;
+
+use crate::ListenerConfig;
+
+/// Keystone internal API interface.
+#[derive(Debug, Deserialize, Clone)]
+pub struct InternalInterface {
+    /// Default address to use for the Rest API. Defaults to `0.0.0.0:8080`.
+    #[serde(default = "default_public_tcp_address")]
+    pub tcp_address: SocketAddr,
+
+    /// Listener configuration.
+    #[serde(flatten, default)]
+    pub listener: ListenerConfig,
+}
+
+/// Keystone public API interface.
+#[derive(Debug, Deserialize, Clone)]
+pub struct PublicInterface {
+    /// Default address to use for the Rest API. Defaults to `0.0.0.0:8081`.
+    #[serde(default = "default_internal_tcp_address")]
+    pub tcp_address: SocketAddr,
+
+    /// Listener configuration.
+    #[serde(flatten)]
+    pub listener: ListenerConfig,
+}
+
+impl Default for PublicInterface {
+    fn default() -> Self {
+        Self {
+            tcp_address: default_public_tcp_address(),
+            listener: ListenerConfig::Http,
+        }
+    }
+}
+
+fn default_public_tcp_address() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080)
+}
+
+fn default_internal_tcp_address() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8081)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use config::{Config, File, FileFormat};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_deser() {
+        let sot: InternalInterface = serde_json::from_value(json!({
+            "tcp_address": "1.2.3.4:5678",
+            "type": "http",
+        }))
+        .unwrap();
+        assert_eq!(sot.tcp_address.to_string(), "1.2.3.4:5678");
+        if let ListenerConfig::Http = sot.listener {
+        } else {
+            panic!("should be Http listener");
+        }
+        let sot: InternalInterface = serde_json::from_value(json!({
+            "tcp_address": "1.2.3.4:5678",
+            "type": "spiffe",
+            "trust_domains": "a,b,c"
+        }))
+        .unwrap();
+        assert_eq!(sot.tcp_address.to_string(), "1.2.3.4:5678");
+        if let ListenerConfig::Spiffe(s) = sot.listener {
+            assert!(s.trust_domains.contains(&String::from("a")));
+        } else {
+            panic!("should be Http listener");
+        }
+    }
+
+    #[test]
+    fn test_deser_ini() {
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+tcp_address = "1.2.3.4:5678"
+type = http
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let sot: InternalInterface = c.try_deserialize().unwrap();
+        assert_eq!(sot.tcp_address.to_string(), "1.2.3.4:5678");
+        if let ListenerConfig::Http = sot.listener {
+        } else {
+            panic!("should be Http listener");
+        }
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+tcp_address = "1.2.3.4:5678"
+type = spiffe
+trust_domains = "a,b,c"
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let sot: InternalInterface = c.try_deserialize().unwrap();
+        assert_eq!(sot.tcp_address.to_string(), "1.2.3.4:5678");
+        if let ListenerConfig::Spiffe(s) = sot.listener {
+            assert!(s.trust_domains.contains(&String::from("a")));
+        } else {
+            panic!("should be Http listener");
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -67,6 +67,7 @@ mod federation;
 mod fernet_token;
 mod identity;
 mod identity_mapping;
+mod interface;
 mod k8s_auth;
 mod listener;
 mod policy;
@@ -91,6 +92,7 @@ pub use federation::*;
 pub use fernet_token::*;
 pub use identity::*;
 pub use identity_mapping::*;
+pub use interface::*;
 pub use k8s_auth::*;
 pub use listener::*;
 pub use policy::*;
@@ -157,9 +159,13 @@ pub struct Config {
     #[serde(default)]
     pub k8s_auth: K8sAuthProvider,
 
-    /// Server listener configuration.
-    #[serde(default)]
-    pub listener: Listener,
+    /// Server listener configuration for the internal interface.
+    #[serde(rename = "interface_internal", default)]
+    pub interface_internal: Option<InternalInterface>,
+
+    /// Server listener configuration for the internal interface.
+    #[serde(rename = "interface_public", default)]
+    pub interface_public: PublicInterface,
 
     /// Resource provider configuration.
     #[serde(default)]
@@ -231,14 +237,11 @@ impl Config {
     /// - `Ok(Self)` if the config was parsed successfully
     pub fn load_all(path: PathBuf) -> Result<Self, Report> {
         let mut cfg = Self::new(path)?;
-        if let Some(ref mut ds) = cfg.distributed_storage {
-            ds.tls_configuration
-                .read_certs()
-                .wrap_err("reading distributed storage TLS configuration")?;
-        }
-        if let Some(ref mut tls) = cfg.listener.tls_configuration {
+        if let Some(ref mut ds) = cfg.distributed_storage
+            && let RaftTlsConfiguration::Tls(ref mut tls) = ds.tls_configuration
+        {
             tls.read_certs()
-                .wrap_err("reading listener TLS configuration")?;
+                .wrap_err("reading distributed storage TLS configuration")?;
         }
         Ok(cfg)
     }
@@ -246,18 +249,9 @@ impl Config {
     /// Get the list of all files that should be watched.
     fn get_watch_files(&self) -> HashSet<PathBuf> {
         let mut watched_paths = HashSet::new();
-        if let Some(ds) = &self.distributed_storage {
-            if let Some(crt) = &ds.tls_configuration.tls_cert_file {
-                watched_paths.insert(crt.clone());
-            }
-            if let Some(key) = &ds.tls_configuration.tls_key_file {
-                watched_paths.insert(key.clone());
-            }
-            if let Some(ca) = &ds.tls_configuration.tls_client_ca_file {
-                watched_paths.insert(ca.clone());
-            }
-        }
-        if let Some(tls) = &self.listener.tls_configuration {
+        if let Some(ds) = &self.distributed_storage
+            && let RaftTlsConfiguration::Tls(tls) = &ds.tls_configuration
+        {
             if let Some(crt) = &tls.tls_cert_file {
                 watched_paths.insert(crt.clone());
             }
@@ -360,12 +354,12 @@ impl ConfigManager {
 
         // Register file watches
         for watch in watched_paths.iter() {
-            let _ = watcher.watch(&watch.as_path(), RecursiveMode::NonRecursive);
+            let _ = watcher.watch(watch.as_path(), RecursiveMode::NonRecursive);
         }
 
         while let Some(_event) = sync_rx.recv().await {
             // 1. Drain the channel to ignore rapid-fire events
-            while let Ok(_) = sync_rx.try_recv() {}
+            while sync_rx.try_recv().is_ok() {}
 
             // Give the OS a moment to finish the file write
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -376,7 +370,7 @@ impl ConfigManager {
                     for watch_candidate in new_cfg.get_watch_files() {
                         if !watched_paths.contains(&watch_candidate) {
                             let _ = watcher
-                                .watch(&watch_candidate.as_path(), RecursiveMode::NonRecursive);
+                                .watch(watch_candidate.as_path(), RecursiveMode::NonRecursive);
                             watched_paths.insert(watch_candidate.clone());
                         }
                     }
@@ -413,11 +407,11 @@ mod tests {
             write!(
                 cfg_file,
                 r#"
-[auth]
-methods = []
-[database]
-connection = "foo"
-            "#
+    [auth]
+    methods = []
+    [database]
+    connection = "foo"
+                "#
             )
             .unwrap();
 
@@ -432,11 +426,15 @@ connection = "foo"
         write!(
             site_vars_file,
             r#"
-[distributed_storage]
-node_id = 1
-cluster_addr = "http://foo:8300"
-path = "/tmp"
-        "#
+    [distributed_storage]
+    node_id = 1
+    node_cluster_addr = "http://foo:8300"
+    path = "/tmp"
+    type = "tls"
+    tls_key_file = "/foo"
+    tls_cert_file = "/bar"
+    tls_client_ca_file = "/baz"
+            "#
         )
         .unwrap();
         temp_env::with_var(
@@ -447,39 +445,64 @@ path = "/tmp"
                 write!(
                     cfg_file,
                     r#"
-[auth]
-methods = []
-[database]
-connection = "foo"
-            "#
+    [auth]
+    methods = []
+    [database]
+    connection = "foo"
+                "#
                 )
                 .unwrap();
 
                 let cfg = Config::new(cfg_file.path().to_path_buf()).unwrap();
                 let ds = cfg.distributed_storage.unwrap();
                 assert_eq!(1, ds.node_id);
-                assert_eq!("http://foo:8300/", ds.cluster_addr.to_string());
+                assert_eq!("http://foo:8300/", ds.node_cluster_addr.to_string());
             },
         );
     }
 
+    #[test]
+    fn test_listener_internal() {
+        let c = config::Config::builder()
+            .add_source(File::from_str(
+                r#"
+            [auth]
+            methods = []
+            [database]
+            connection = "foo"
+            [interface_internal]
+            tcp_addr = "1.2.3.4:5678"
+            type = "spiffe"
+            trust_domains = "example.org"
+            "#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let cfg: Config = c.try_deserialize().unwrap();
+        if let Some(internal_if) = &cfg.interface_internal {
+            if let ListenerConfig::Spiffe(spiffe) = &internal_if.listener {
+                assert!(spiffe.trust_domains.contains(&String::from("example.org")));
+            } else {
+                panic!("should be regular tls");
+            }
+        } else {
+            panic!("internal interface should be there");
+        }
+    }
+
     // Helper to setup a dummy config and cert file
-    fn setup_files(
-        dir: &std::path::Path,
-        //cert_name: Some(&str),
-        //cert_content: &str,
-    ) -> std::path::PathBuf {
+    fn setup_files(dir: &std::path::Path) -> std::path::PathBuf {
         let config_path = dir.join("keystone.conf");
 
-        //let mut cfg_file = NamedTempFile::new().unwrap();
         let mut f = fs::File::create(&config_path).unwrap();
         f.write_all(
             r#"
-[auth]
-methods = []
-[database]
-connection = "foo"
-            "#
+    [auth]
+    methods = []
+    [database]
+    connection = "foo"
+                "#
             .as_bytes(),
         )
         .unwrap();
@@ -524,11 +547,11 @@ connection = "foo"
         fs::write(
             &config_path,
             r#"
-[auth]
-methods = []
-[database]
-connection = "bar"
-"#,
+    [auth]
+    methods = []
+    [database]
+    connection = "bar"
+    "#,
         )
         .unwrap();
 
@@ -548,7 +571,6 @@ connection = "bar"
 
     #[tokio::test]
     async fn test_reload_on_cert_change() {
-        //let dir = tempdir().unwrap();
         let config_file = NamedTempFile::with_suffix(".conf").unwrap();
         let mut ca_file = NamedTempFile::new().unwrap();
         write!(ca_file, "ca").unwrap();
@@ -556,22 +578,22 @@ connection = "bar"
         write!(cert_file, "cert").unwrap();
         let mut key_file = NamedTempFile::new().unwrap();
         write!(key_file, "key").unwrap();
-        let mut f = fs::File::create(&config_file.path()).unwrap();
+        let mut f = fs::File::create(config_file.path()).unwrap();
         f.write_all(
             format!(
                 r#"
-[auth]
-methods = []
-[database]
-connection = "foo"
-[distributed_storage]
-cluster_addr = https://localhost:8310
-node_id = 1
-path = /keystone/storage
-tls_key_file = {:?}
-tls_cert_file = {:?}
-tls_client_ca_file = {:?}
-            "#,
+    [auth]
+    methods = []
+    [database]
+    connection = "foo"
+    [distributed_storage]
+    node_cluster_addr = https://localhost:8310
+    node_id = 1
+    path = /keystone/storage
+    tls_key_file = {:?}
+    tls_cert_file = {:?}
+    tls_client_ca_file = {:?}
+                "#,
                 key_file.path(),
                 cert_file.path(),
                 ca_file.path()
@@ -594,7 +616,7 @@ tls_client_ca_file = {:?}
         let mut f = std::fs::OpenOptions::new()
             .write(true)
             .truncate(true)
-            .open(&cert_file.path())
+            .open(cert_file.path())
             .unwrap();
         f.write_all("another cert".as_bytes()).unwrap();
 
@@ -604,13 +626,10 @@ tls_client_ca_file = {:?}
         for _ in 0..10 {
             sleep(Duration::from_millis(200)).await;
             let updated = mgr.config.read().await;
-            if updated
-                .distributed_storage
-                .as_ref()
-                .and_then(|x| x.tls_configuration.tls_cert_content.clone())
-                .as_ref()
-                .map(|x| x.expose_secret())
-                == Some("another cert".as_bytes())
+            if let Some(ds) = &updated.distributed_storage
+                && let RaftTlsConfiguration::Tls(data) = &ds.tls_configuration
+                && data.tls_cert_content.as_ref().map(|x| x.expose_secret())
+                    == Some("another cert".as_bytes())
             {
                 success = true;
                 break;

--- a/crates/config/src/listener.rs
+++ b/crates/config/src/listener.rs
@@ -11,117 +11,86 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+//! # Server listeners
 
 use serde::Deserialize;
 
-use crate::common::TlsConfiguration;
+use crate::common::csv;
 
-/// Server listener section.
-#[derive(Debug, Deserialize, Clone)]
-pub struct Listener {
-    /// Default address to use for the server to server communication. This
-    /// defaults to one port higher than the value of address.
-    #[serde(default)]
-    pub cluster_address: Option<SocketAddr>,
-
-    /// Default address to use for the Rest API. Defaults to `0.0.0.0:8080`.
-    #[serde(default = "default_tcp_address")]
-    pub tcp_address: SocketAddr,
-
-    /// TLS configuration for the server listener.
-    #[serde(default)]
-    #[serde(flatten)]
-    pub tls_configuration: Option<TlsConfiguration>,
+/// Server listener configuration.
+#[derive(Debug, Default, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ListenerConfig {
+    Spiffe(SpiffeListener),
+    #[default]
+    Http,
 }
 
-impl Default for Listener {
-    fn default() -> Self {
-        Self {
-            cluster_address: None,
-            tcp_address: default_tcp_address(),
-            tls_configuration: None,
-        }
-    }
-}
-
-impl Listener {
-    /// Get cluster address.
-    ///
-    /// Obtain the address to use for the server to server communication. This
-    /// defaults to one port higher than the value of address.
-    pub fn get_cluster_address(&self) -> SocketAddr {
-        match self.cluster_address {
-            Some(addr) => addr,
-            None => SocketAddr::new(self.tcp_address.ip(), self.tcp_address.port() + 1),
-        }
-    }
-}
-
-fn default_tcp_address() -> SocketAddr {
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080)
+/// Server listener with SPIFFE mTLS support.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct SpiffeListener {
+    /// Trusted domains to accept SPIFFE certificates from clients.
+    #[serde(deserialize_with = "csv")]
+    pub trust_domains: Vec<String>,
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
     use config::{Config, File, FileFormat};
-    use serde_json::json;
-    use tempfile::NamedTempFile;
 
     use super::*;
-
-    #[test]
-    fn test_deser() {
-        let cfg: Listener = serde_json::from_value(json!({
-            "tcp_address": "127.1.1.1:1234"
-        }))
-        .unwrap();
-        assert_eq!(
-            cfg.tcp_address,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 1, 1, 1)), 1234)
-        );
-    }
 
     #[test]
     fn test_deser_ini() {
         let c = Config::builder()
             .add_source(File::from_str(
                 r#"
-tcp_address = 128.0.0.1:1234
+type = "http"
 "#,
                 FileFormat::Ini,
             ))
             .build()
             .unwrap();
-        let cfg: Listener = c.try_deserialize().unwrap();
-        assert_eq!(
-            cfg.tcp_address,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(128, 0, 0, 1)), 1234)
-        );
-    }
-
-    #[test]
-    fn test_env() {
-        temp_env::with_vars(
-            [("OS_LISTENER__TCP_ADDRESS", Some("127.0.0.1:8080"))],
-            || {
-                let mut cfg_file = NamedTempFile::new().unwrap();
-                write!(
-                    cfg_file,
-                    r#"
-[auth]
-methods = []
-[database]
-connection = "foo"
-            "#
-                )
-                .unwrap();
-
-                let cfg = crate::Config::new(cfg_file.path().to_path_buf()).unwrap();
-                assert_eq!("127.0.0.1:8080", cfg.listener.tcp_address.to_string());
-            },
-        );
+        let sot: ListenerConfig = c.try_deserialize().unwrap();
+        if let ListenerConfig::Http = sot {
+        } else {
+            panic!("should be Http listener");
+        }
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+type = spiffe
+trust_domains = "a,b,c"
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let sot: ListenerConfig = c.try_deserialize().unwrap();
+        if let ListenerConfig::Spiffe(s) = sot {
+            assert!(s.trust_domains.contains(&String::from("a")));
+        } else {
+            panic!("should be spiffe listener");
+        }
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+type = spiffe
+trust_domains = ""
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let sot: ListenerConfig = c.try_deserialize().unwrap();
+        if let ListenerConfig::Spiffe(s) = sot {
+            assert!(
+                s.trust_domains.is_empty(),
+                "must be empty, instead is {:?}",
+                s.trust_domains
+            );
+        } else {
+            panic!("should be spiffe listener");
+        }
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 async-trait.workspace = true
 axum = { workspace = true, default-features = false, features = ["json"], optional = true }
+#axum-server.workspace = true
 base64.workspace = true
 bcrypt = { workspace = true, features = ["alloc"] }
 chrono = { workspace = true, default-features = false }
@@ -25,11 +26,13 @@ openstack-keystone-distributed-storage = { version = "0.1", path = "../storage/"
 mockall = { workspace = true, optional = true }
 rand.workspace = true
 reqwest = { workspace = true, features = ["json", "http2", "gzip", "deflate"] }
+#rustls.workspace = true
 sea-orm.workspace = true
 secrecy = { workspace = true, features = ["serde"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
+spiffe.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -16,8 +16,11 @@ use axum::{
     extract::{FromRef, FromRequestParts},
     http::request::Parts,
 };
+use spiffe::SpiffeId;
 use std::sync::Arc;
 use tracing::{debug, error};
+
+use openstack_keystone_config::Interface;
 
 use crate::api::KeystoneApiError;
 use crate::keystone::ServiceState;
@@ -35,6 +38,17 @@ where
 
     #[tracing::instrument(skip(state), err)]
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        if let Some(svid) = parts.extensions.get::<SpiffeId>() {
+            tracing::info!("the svid is {:?}", svid);
+        }
+        // Extract the interface on which the connection is being served
+        let interface = parts
+            .extensions
+            .get::<Interface>()
+            .cloned()
+            .unwrap_or(Interface::Public);
+        tracing::info!("the interface is {:?}", interface);
+
         let auth_header = parts
             .headers
             .get("X-Auth-Token")

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -28,6 +28,9 @@ clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
 derive_builder.workspace = true
 eyre.workspace = true
+futures-util.workspace = true
+hyper-util.workspace = true
+hyper.workspace = true
 openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "../api-types/"}
 openstack-keystone-appcred-sql = { version = "0.1", path = "../appcred-sql/" }
 openstack-keystone-assignment-sql = { version = "0.1", path = "../assignment-sql/" }
@@ -57,8 +60,12 @@ secrecy = { workspace = true, features = ["serde"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
+spiffe = { workspace = true, features = ["x509-source"] }
+spiffe-rustls = "0.5.0"
+spiffe-rustls-tokio = "0.2"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "signal", "rt-multi-thread"] }
+tokio-rustls.workspace = true
 tokio-util.workspace = true
 tonic = { workspace = true, features = ["server", "tls-aws-lc" ] }
 tower.workspace = true

--- a/crates/keystone/src/api/tls2.rs
+++ b/crates/keystone/src/api/tls2.rs
@@ -1,0 +1,284 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Main Keystone executable.
+//!
+//! This is the entry point of the `keystone` binary.
+
+use std::sync::Arc;
+
+use axum::Router;
+use color_eyre::eyre::{OptionExt, Report, Result};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder;
+use rustls::client::danger::HandshakeSignatureValid;
+use rustls::pki_types::{CertificateDer, UnixTime};
+use rustls::pki_types::{PrivateKeyDer, pem::PemObject};
+use spiffe_rustls_tokio::TlsAcceptor;
+use tokio::signal;
+//use rustls::server::WebPkiClientVerifier;
+use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+use rustls::{DigitallySignedStruct, DistinguishedName, SignatureScheme};
+use secrecy::ExposeSecret;
+use spiffe_rustls::{authorizer, mtls_server};
+use tokio::net::TcpListener;
+//use tokio_rustls::TlsAcceptor;
+use tokio_util::sync::CancellationToken;
+//use tonic::transport::{Certificate, Identity, ServerTlsConfig};
+use tower::Service;
+//use tower::ServiceBuilder;
+use tracing::info;
+
+use openstack_keystone_core::api::auth::RawClientCertificate;
+
+use crate::config::Config;
+//use crate::keystone::ServiceState;
+
+#[derive(Debug)]
+pub struct KeystoneVerifier;
+
+impl ClientCertVerifier for KeystoneVerifier {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    // We return empty hints to keep the handshake small
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &[]
+    }
+
+    fn verify_client_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _now: UnixTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        // In a dynamic system, we accept the cert at the handshake level.
+        // The middleware will perform the actual CA-validation against
+        // the database-backed root certificates.
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ED25519,
+            SignatureScheme::RSA_PKCS1_SHA256,
+        ]
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        false
+    }
+    fn requires_raw_public_keys(&self) -> bool {
+        false
+    }
+}
+
+/// Start the Axum REST api with the permissive mTLS enabled.
+///
+/// The TLS server is started requesting the client certificates, but not
+/// requiring them. When a certificate is present (on a Transport layer) it is
+/// passed as an extension to the regular authentication extractor (application
+/// layer) where it can be checked against a DB backed list of CAs.
+pub async fn start_rest_api_with_mtls(
+    addr: std::net::SocketAddr,
+    app: Router,
+    config: Config,
+    //shared_state: ServiceState,
+    token: CancellationToken,
+) -> Result<(), Report> {
+    //let cert_file = "";
+    // config
+    //     .distributed_storage
+    //     .as_ref()
+    //     .and_then(|ds| ds.tls_configuration.tls_cert_file.clone())
+    //     .ok_or_else(|| {
+    //         color_eyre::eyre::eyre!("TLS certificate file not configured for REST
+    // API")     })?;
+
+    //let key_file = "";
+    // config
+    //     .distributed_storage
+    //     .as_ref()
+    //     .and_then(|ds| ds.tls_configuration.tls_key_file.clone())
+    //     .ok_or_else(|| color_eyre::eyre::eyre!("TLS key file not configured for
+    // REST API"))?;
+
+    //let config = axum_server::rustls::RustlsConfig::from_pem_file(cert_file,
+    // key_file)    .await
+    //    .wrap_err("Failed to load TLS config")?;
+
+    // 1. CONFIGURE TLS: This is the "Request but not Require" magic
+    if let Some(tls_config) = config.listener.tls_configuration {
+        // spiffe
+        // TODO: the SPIFFE_ENDPOINT_SOCKET env must be set and start with unix:///tmp/....
+        // TODO: do not start SPIFFE when env is not set - raise error or switch to normal TLS
+        // Establish connection to SPIFFE is a blocking operation. Operator may want to abort the
+        // process when such connection hangs, so we need to have a dedicated signal handling.
+        let source = tokio::select! {
+            res = spiffe::X509Source::new() => {res?}
+            _ = signal::ctrl_c() => {
+                tracing::info!("Ctrl+C signal received while waiting for the SPIFFE communication");
+                return Ok(())
+            }
+        };
+        let spiffe_server_config = Arc::new(
+            mtls_server(source)
+                .authorize(authorizer::trust_domains(["example.org"])?)
+                .build()?,
+        );
+
+        // non-spiffe
+        let certs: Vec<CertificateDer> = CertificateDer::pem_slice_iter(
+            tls_config
+                .tls_cert_content
+                .as_ref()
+                .ok_or_eyre("TLS certificate is missing")?
+                .expose_secret(),
+        )
+        //.unwrap()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        // 2. Load the Private Key
+        let key = PrivateKeyDer::from_pem_slice(
+            tls_config
+                .tls_key_content
+                .ok_or_eyre("TLS key is missing")?
+                .expose_secret(),
+        )
+        .unwrap();
+
+        //let mut roots = rustls::RootCertStore::empty();
+        //let ca_certs: Vec<CertificateDer> = //vec![CertificateDer::from_pem_slice("".as_bytes()).unwrap()];
+        //Cert//ificateDer::pem_file_iter("/etc/keystone/keystone.crt")
+        //.unwrap()
+        //.collect::<Result<Vec<_>, _>>()?;
+        //roots
+        //.add_parsable_certificates(certs.clone()) //rustls_webpki::anchor_from_trusted_cert().unwrap())
+        //;
+        //let client_verifier = WebPkiClientVerifier::builder(roots.into())
+        //    .allow_unauthenticated() // <--- CRITICAL: Handshake succeeds even without cert
+        //    .build()
+        //    .unwrap();
+
+        let tls_config = Arc::new(
+            rustls::ServerConfig::builder()
+                .with_client_cert_verifier(Arc::new(KeystoneVerifier))
+                .with_single_cert(certs, key)
+                .unwrap(),
+        );
+
+        let acceptor = TlsAcceptor::from(spiffe_server_config);
+        //let rustls_config =
+        // axum_server::tls_rustls::RustlsConfig::from_config(server_config.into());
+        //.with_no_client_auth();
+        //.with_safe_default_protocol_versions()
+        //.unwrap();
+
+        info!("Starting Rest API at {:?} with optional mTLS", addr);
+        //bind_rustls(addr, rustls_config)
+        //    .handle(shared_state.server_handle)
+        //    .serve(app.into_make_service())
+        //    //.with_graceful_shutdown(shutdown_signal(shared_state))
+        //    .await
+        //    .map_err(|e| color_eyre::eyre::eyre!("Server error: {e}"))?;
+        let listener = TcpListener::bind(&config.listener.tcp_address).await?;
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => break,
+                Ok((stream, peer_addr)) = listener.accept() => {
+                    let acceptor = acceptor.clone();
+                    let app = app.clone();
+                    let conn_token = token.clone();
+
+                    tokio::spawn(async move {
+                        let tls_stream = match acceptor.accept(stream).await {
+                            Ok(s) => s,
+                            Err(e) => {
+                                tracing::info!("TLS Handshake failed for {}: {}", peer_addr, e);
+                                return;
+                            }
+                        };
+
+                        // Extract peer certificates from the TLS session
+                        let (_, session) = tls_stream.get_ref();
+                        let peer_certs = session.peer_certificates().map(|c| c.to_vec());
+
+                        let hyper_service = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                            let mut app = app.clone();
+                            let certs = peer_certs.clone();
+                            async move {
+                                let mut req = req;
+                                if let Some(chain) = certs {
+                                    // Move the client TLS certificate into the request extensions
+                                    tracing::debug!("The client supplied certificates: {:?}", chain);
+                                    req.extensions_mut().insert(RawClientCertificate(chain));
+                                }
+                                // Call Axum and explicitly wrap the result
+                                app.call(req).await
+                                //let res = app.call(req).await.unwrap();
+
+                                //// Use the turbofish operator to satisfy the Result<Response, Error> bound
+                                //Ok::<_, std::convert::Infallible>(res)
+                            }
+                        });
+
+                        let builder = Builder::new(TokioExecutor::new());
+                        let conn = builder.serve_connection(TokioIo::new(tls_stream), hyper_service);
+
+                        // Pinning is often required for select! on hyper futures
+                        tokio::pin!(conn);
+
+                        tokio::select! {
+                            res = &mut conn => {
+                                // Normal completion
+                                if let Err(err) = res {
+                                    eprintln!("Connection error: {:?}", err);
+                                }
+                            },
+                            _ = conn_token.cancelled() => {
+                                // Signal hyper to stop accepting new requests on this keep-alive connection
+                                tracing::debug!("received shutdown in the TLS serve loop");
+                                conn.as_mut().graceful_shutdown();
+                                // Wait for the current request to finish
+                                let _ = conn.await;
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -15,7 +15,6 @@
 //!
 //! This is the entry point of the `keystone` binary.
 
-use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -30,9 +29,9 @@ use clap::{Parser, ValueEnum};
 use color_eyre::eyre::{Report, Result, WrapErr};
 use sea_orm::{ConnectOptions, Database};
 use secrecy::ExposeSecret;
-use tokio::{net::TcpListener, signal, spawn, time};
+use tokio::net::TcpListener;
+use tokio::{signal, spawn, time};
 use tokio_util::sync::CancellationToken;
-use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 use tower::ServiceBuilder;
 use tower_http::{
     LatencyUnit, ServiceBuilderExt,
@@ -49,15 +48,16 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
 
-use openstack_keystone::config::ConfigManager;
+use openstack_keystone::config::{ConfigManager, Interface, ListenerConfig};
 use openstack_keystone::federation::FederationApi;
-use openstack_keystone::keystone::{Service, ServiceState};
+use openstack_keystone::keystone::Service as KeystoneServiceState;
+use openstack_keystone::keystone::ServiceState;
 use openstack_keystone::plugin_manager::PluginManager;
 use openstack_keystone::policy::HttpPolicyEnforcer;
 use openstack_keystone::provider::Provider;
+use openstack_keystone::server::listener::{raft_grpc, spiffe_tls};
 use openstack_keystone::webauthn;
 use openstack_keystone::{api, common};
-use openstack_keystone_distributed_storage::app::get_app_server;
 
 // Default body limit 256kB
 const DEFAULT_BODY_LIMIT: usize = 1024 * 256;
@@ -216,7 +216,8 @@ async fn main() -> Result<(), Report> {
     let provider = Provider::new(&cfg, &plugin_manager)?;
     let policy = HttpPolicyEnforcer::new(cfg.api_policy.opa_base_url.clone()).await?;
 
-    let shared_state = Arc::new(Service::new(cfg_mgr, conn, provider, Arc::new(policy)).await?);
+    let shared_state =
+        Arc::new(KeystoneServiceState::new(cfg_mgr, conn, provider, Arc::new(policy)).await?);
 
     spawn(cleanup(cloned_token, shared_state.clone()));
 
@@ -262,6 +263,7 @@ async fn main() -> Result<(), Report> {
         .sensitive_response_headers(sensitive_headers)
         // propagate the header to the response before the response reaches `TraceLayer`
         .layer(PropagateRequestIdLayer::new(x_request_id));
+    //.layer(middleware::from_fn(cert_extension_middleware));
 
     let mut app = Router::new().merge(main_router.with_state(shared_state.clone()));
 
@@ -285,107 +287,84 @@ async fn main() -> Result<(), Report> {
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
         .layer(middleware);
 
+    // Shutdown watcher
+    let global_shutdown_token = token.clone();
+    let signal_state = shared_state.clone();
+    tokio::spawn(async move {
+        // Your existing handler that takes Arc<AppState>
+        // Instead of calling handle.graceful_shutdown, just cancel the token
+        shutdown_signal(signal_state).await;
+        global_shutdown_token.cancel();
+    });
+
     let mut handles = tokio::task::JoinSet::new();
-    if let Some(ds) = &cfg.distributed_storage
-        && let Some(storage) = &shared_state.storage
-    {
-        let storage_app = get_app_server(storage).await?;
 
-        let state_clone = shared_state.clone();
-
-        let mut server = tonic::transport::Server::builder();
-        // Without an explicit select of the default provider the initialization fails
-        // since some of the dependencies cause rustls to have `ring` and
-        // `aws_lc_rs` enabled.
-        let provider = rustls::crypto::aws_lc_rs::default_provider();
-        rustls::crypto::CryptoProvider::install_default(provider).unwrap();
-
-        // CA is used to validate client and peer connections
-        let identity = Identity::from_pem(
-            ds.tls_configuration
-                .tls_cert_content
-                .as_ref()
-                .or(cfg
-                    .listener
-                    .tls_configuration
-                    .as_ref()
-                    .and_then(|x| x.tls_cert_content.as_ref()))
-                .expect("TLS cert missing")
-                .expose_secret(),
-            ds.tls_configuration
-                .tls_key_content
-                .as_ref()
-                .or(cfg
-                    .listener
-                    .tls_configuration
-                    .as_ref()
-                    .and_then(|x| x.tls_key_content.as_ref()))
-                .expect("TLS key missing")
-                .expose_secret(),
-        );
-        let mut server_tls_config = ServerTlsConfig::new().identity(identity);
-        if let Some(ca) = &ds.tls_configuration.tls_client_ca_content.as_ref().or(cfg
-            .listener
-            .tls_configuration
-            .as_ref()
-            .and_then(|x| x.tls_client_ca_content.as_ref()))
-        {
-            server_tls_config =
-                server_tls_config.client_ca_root(Certificate::from_pem(ca.expose_secret()));
-        }
-        server = server.tls_config(server_tls_config)?;
-        let tonic_router = server.add_routes(storage_app);
-
-        let grpc_addr = shared_state
-            .config_manager
-            .config
-            .read()
-            .await
-            .listener
-            .get_cluster_address();
-        info!("Starting distributed storage at {:?}", grpc_addr);
+    // Raft
+    if cfg.distributed_storage.is_some() {
+        let raft_cancel_token = token.clone();
+        let raft_state = shared_state.clone();
+        let raft_config = cfg.clone();
         handles.spawn(async move {
-            tonic_router
-                .serve_with_shutdown(grpc_addr, shutdown_signal(state_clone))
+            raft_grpc::start_raft_app(raft_state, raft_config, raft_cancel_token)
                 .await
-                .unwrap();
+                .unwrap()
         });
+        raft_grpc::ensure_raft_initialized(shared_state.clone(), cfg.clone()).await?;
+    }
 
-        if !storage.raft.is_initialized().await?
-            && ds.node_id == 0
-            && let (Some(host), Some(port)) = (ds.cluster_addr.host(), ds.cluster_addr.port())
-        {
-            info!("Initializing the integrated storage since it is not initialized.");
-            storage
-                .raft
-                .initialize(HashMap::from([(
-                    0,
-                    openstack_keystone_distributed_storage::pb::raft::Node {
-                        node_id: 0,
-                        rpc_addr: format!("{host}:{port}"),
-                    },
-                )]))
-                .await?;
+    // Start the public interface listener
+    match cfg.interface_public.listener {
+        ListenerConfig::Http => {
+            info!("Starting Rest API at {}", cfg.interface_public.tcp_address);
+            let listener = TcpListener::bind(&cfg.interface_public.tcp_address).await?;
+            let rest_cancel_token = token.clone();
+            let rest_app = app.clone();
+            handles.spawn(async move {
+                axum::serve(listener, rest_app.into_make_service())
+                    .with_graceful_shutdown(async move {
+                        rest_cancel_token.cancelled().await;
+                    })
+                    .await
+                    .unwrap();
+            });
+        }
+        _ => {
+            // TODO: implement spiffe listener for public IF
+            error!("only HTTP is supported for public interface");
         }
     }
 
-    let listener = TcpListener::bind(
-        &shared_state
-            .config_manager
-            .config
-            .read()
-            .await
-            .listener
-            .tcp_address,
-    )
-    .await?;
-    info!("Starting Rest API at {:?}", listener.local_addr());
-    handles.spawn(async move {
-        axum::serve(listener, app.into_make_service())
-            .with_graceful_shutdown(shutdown_signal(shared_state))
-            .await
-            .unwrap();
-    });
+    // Start listener on the internal interface when necessary
+    if let Some(internal_if) = &cfg.interface_internal {
+        match &internal_if.listener {
+            ListenerConfig::Spiffe(spiffe) => {
+                // Spiffe listener
+                let rest_addr = internal_if.tcp_address.clone();
+                let rest_app = app.clone();
+                let rest_cancel_token = token.clone();
+                let rest_spiffe_trust_domains = spiffe.trust_domains.clone();
+
+                handles.spawn(async move {
+                    let cancel_token = rest_cancel_token.clone();
+                    if let Err(e) = spiffe_tls::start_axum_app(
+                        rest_addr,
+                        rest_app,
+                        rest_cancel_token,
+                        rest_spiffe_trust_domains,
+                        Interface::Internal,
+                    )
+                    .await
+                    {
+                        error!("REST API server error: {e}");
+                        cancel_token.cancel();
+                    }
+                });
+            }
+            _ => {
+                error!("only SPIFFE is supported for internal interface");
+            }
+        }
+    }
 
     // Wait for both (or handle errors)
     handles.join_all().await;
@@ -393,7 +372,6 @@ async fn main() -> Result<(), Report> {
     Ok(())
 }
 
-/// Periodic cleanup job.
 async fn cleanup(cancel: CancellationToken, state: ServiceState) {
     let mut interval = time::interval(Duration::from_secs(60));
     interval.tick().await;

--- a/crates/keystone/src/lib.rs
+++ b/crates/keystone/src/lib.rs
@@ -92,6 +92,7 @@ pub mod provider;
 pub mod resource;
 pub mod revoke;
 pub mod role;
+pub mod server;
 pub mod token;
 pub mod trust;
 pub mod webauthn;

--- a/crates/keystone/src/server.rs
+++ b/crates/keystone/src/server.rs
@@ -1,0 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Keystone server listeners
+pub mod listener;

--- a/crates/keystone/src/server/listener.rs
+++ b/crates/keystone/src/server/listener.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Keystone API listeners
+pub mod raft_grpc;
+pub mod spiffe_tls;

--- a/crates/keystone/src/server/listener/raft_grpc.rs
+++ b/crates/keystone/src/server/listener/raft_grpc.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Main Keystone executable.
+//!
+//! This is the entry point of the `keystone` binary.
+use std::collections::HashMap;
+
+use color_eyre::eyre::{Report, Result};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use openstack_keystone_distributed_storage::{app::get_app_server, network::get_server_tls_config};
+
+use crate::config::Config;
+use crate::keystone::ServiceState;
+
+/// Start Raft backed distributed storage.
+pub async fn start_raft_app(
+    state: ServiceState,
+    config: Config,
+    cancel_token: CancellationToken,
+) -> Result<(), Report> {
+    if let Some(ds) = &config.distributed_storage
+        && let Some(storage) = &state.storage
+    {
+        let storage_app = get_app_server(storage).await?;
+
+        //let state_clone = shared_state.clone();
+
+        // Without an explicit select of the default provider the initialization fails
+        // since some of the dependencies cause rustls to have `ring` and
+        // `aws_lc_rs` enabled.
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        rustls::crypto::CryptoProvider::install_default(provider).unwrap();
+
+        let mut server =
+            tonic::transport::Server::builder().tls_config(get_server_tls_config(&config)?)?;
+
+        let tonic_router = server.add_routes(storage_app);
+
+        let grpc_addr = ds.node_listener_addr;
+        info!("Starting distributed storage at {:?}", grpc_addr);
+
+        tonic_router
+            .serve_with_shutdown(grpc_addr, async move {
+                cancel_token.cancelled().await;
+            })
+            .await
+            .unwrap();
+    }
+
+    Ok(())
+}
+
+/// Ensure Raft cluster is initialized with at least the current node.
+pub async fn ensure_raft_initialized(state: ServiceState, config: Config) -> Result<(), Report> {
+    if let Some(ds) = &config.distributed_storage
+        && let Some(storage) = &state.storage
+    {
+        if !storage.raft.is_initialized().await?
+            && ds.node_id == 0
+            && let (Some(host), Some(port)) =
+                (ds.node_cluster_addr.host(), ds.node_cluster_addr.port())
+        {
+            info!("Initializing the integrated storage since it is not initialized.");
+            storage
+                .raft
+                .initialize(HashMap::from([(
+                    0,
+                    openstack_keystone_distributed_storage::pb::raft::Node {
+                        node_id: 0,
+                        rpc_addr: format!("{host}:{port}"),
+                    },
+                )]))
+                .await?;
+        }
+    }
+    Ok(())
+}

--- a/crates/keystone/src/server/listener/spiffe_tls.rs
+++ b/crates/keystone/src/server/listener/spiffe_tls.rs
@@ -1,0 +1,145 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Main Keystone executable.
+//!
+//! This is the entry point of the `keystone` binary.
+
+use std::sync::Arc;
+
+use axum::Router;
+use color_eyre::eyre::{Report, Result, eyre};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder;
+use spiffe_rustls::{authorizer, mtls_server};
+use spiffe_rustls_tokio::TlsAcceptor;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tower::Service;
+use tracing::info;
+
+use crate::config::Interface;
+
+/// Start the Axum REST api with the SPIFFE mTLS enabled.
+///
+/// The TLS server is started requesting the client certificates verified using the SPIFFE workload
+/// API.
+pub async fn start_axum_app(
+    addr: std::net::SocketAddr,
+    app: Router,
+    token: CancellationToken,
+    trust_domains: Vec<String>,
+    interface: Interface,
+) -> Result<(), Report> {
+    // Establish connection to SPIFFE is a blocking operation. Operator may want to abort the
+    // process when such connection hangs, so we need to have a dedicated signal handling.
+    match std::env::var("SPIFFE_ENDPOINT_SOCKET") {
+        Ok(val) => {
+            if !val.starts_with("unix:///") {
+                return Err(eyre!(
+                    "Variable 'SPIFFE_ENDPOINT_SOCKET' must start with `unix:///` for SPIFFE integration"
+                ));
+            }
+        }
+        Err(_) => {
+            return Err(eyre!(
+                "Variable 'SPIFFE_ENDPOINT_SOCKET' must be set for SPIFFE supported mTLS"
+            ));
+        }
+    }
+    let source = tokio::select! {
+        res = spiffe::X509Source::new() => {res?}
+        _ = token.cancelled() => {
+            tracing::info!("Ctrl+C signal received while waiting for the SPIFFE communication");
+            return Ok(())
+        }
+    };
+    let spiffe_server_config = Arc::new(
+        mtls_server(source)
+            .authorize(authorizer::trust_domains(trust_domains)?)
+            .build()?,
+    );
+
+    let acceptor = TlsAcceptor::from(spiffe_server_config);
+
+    info!("Starting Rest API at {:?} with SPIFFE mTLS", addr);
+    let listener = TcpListener::bind(&addr).await?;
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            Ok((stream, peer_addr)) = listener.accept() => {
+                let acceptor = acceptor.clone();
+                let app = app.clone();
+                let conn_token = token.clone();
+                let interface_clone = interface.clone();
+
+                tokio::spawn(async move {
+                    match acceptor.accept(stream).await {
+                        Ok((tls_stream, peer_identity)) => {
+
+                            let hyper_service = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                                let mut app = app.clone();
+                                let spiffe_id = peer_identity.spiffe_id().cloned();
+                                let interface_clone = interface_clone.clone();
+                                async move {
+                                    let mut req = req;
+                                    if let Some(spiffe_id) = spiffe_id {
+                                        // Move the client TLS certificate into the request extensions
+                                        tracing::debug!("The client supplied certificate for spiffe_id: {:?}", spiffe_id);
+
+                                        req.extensions_mut().insert(spiffe_id);
+                                    }
+                                    req.extensions_mut().insert(interface_clone);
+                                    // Call Axum and explicitly wrap the result
+                                    app.call(req).await
+                                    //let res = app.call(req).await.unwrap();
+
+                                    //// Use the turbofish operator to satisfy the Result<Response, Error> bound
+                                    //Ok::<_, std::convert::Infallible>(res)
+                                }
+                            });
+
+                            let builder = Builder::new(TokioExecutor::new());
+                            let conn = builder.serve_connection(TokioIo::new(tls_stream), hyper_service);
+
+                            // Pinning is required for select! on hyper futures
+                            tokio::pin!(conn);
+
+                            tokio::select! {
+                                res = &mut conn => {
+                                    // Normal completion
+                                    if let Err(err) = res {
+                                        eprintln!("Connection error: {:?}", err);
+                                    }
+                                },
+                                _ = conn_token.cancelled() => {
+                                    // Signal hyper to stop accepting new requests on this keep-alive connection
+                                    tracing::debug!("received shutdown in the TLS serve loop");
+                                    conn.as_mut().graceful_shutdown();
+                                    // Wait for the current request to finish
+                                    let _ = conn.await;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::info!("TLS Handshake failed for {}: {}", peer_addr, e);
+                            return;
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -16,20 +16,20 @@ use rcgen::{
     Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
 use reserve_port::ReservedSocketAddr;
-use secrecy::ExposeSecret;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
-use tonic::transport::{Identity, ServerTlsConfig};
 
 use openstack_keystone_config::{
     Config, ConfigManager, DistributedStorageConfiguration, TlsConfiguration,
     TlsConfigurationBuilder,
 };
-use openstack_keystone_distributed_storage::StorageApi;
-use openstack_keystone_distributed_storage::app::{Storage, get_app_server, init_storage};
-use openstack_keystone_distributed_storage::protobuf as pb;
-use openstack_keystone_distributed_storage::store_command::*;
-use openstack_keystone_distributed_storage::{Metadata, Nonce, StoreDataEnvelope, TypeConfig};
+use openstack_keystone_distributed_storage::{
+    Metadata, Nonce, StorageApi, StoreDataEnvelope, TypeConfig,
+    app::{Storage, get_app_server, init_storage},
+    network::get_server_tls_config,
+    protobuf as pb,
+    store_command::*,
+};
 
 #[allow(dead_code)]
 struct InstanceHolder {
@@ -48,10 +48,13 @@ impl InstanceHolder {
         addr: &SocketAddr,
     ) -> DistributedStorageConfiguration {
         DistributedStorageConfiguration {
-            cluster_addr: format!("https://{}", addr).parse().unwrap(),
+            node_cluster_addr: format!("https://{}", addr).parse().unwrap(),
+            node_listener_addr: addr.clone(),
             node_id: node_id,
             path: db_path,
-            tls_configuration: tls_config.clone(),
+            tls_configuration: openstack_keystone_config::RaftTlsConfiguration::Tls(
+                tls_config.clone(),
+            ),
         }
     }
 
@@ -65,7 +68,7 @@ impl InstanceHolder {
             &addr,
         );
         let mut config = Config::default();
-        config.listener.cluster_address = Some(addr);
+        //config.listener.cluster_address = Some(addr);
         config.distributed_storage = Some(ds_config);
         let storage = init_storage(&ConfigManager::not_watched(config.clone())).await?;
         Ok(Self {
@@ -82,44 +85,21 @@ pub async fn start_raft_app(
     config: &Config,
     storage: &Storage,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let http_addr = config.listener.get_cluster_address();
     let ds_config = config
         .distributed_storage
         .as_ref()
         .expect("ds config must be present");
+    let addr = ds_config.node_listener_addr.clone();
     let node_id = ds_config.node_id;
 
-    let mut server = tonic::transport::Server::builder();
-    let ca = tonic::transport::Certificate::from_pem(
-        &ds_config
-            .tls_configuration
-            .tls_client_ca_content
-            .as_ref()
-            .expect("ca cert must be present")
-            .expose_secret(),
-    );
-    let identity = Identity::from_pem(
-        &ds_config
-            .tls_configuration
-            .tls_cert_content
-            .as_ref()
-            .expect("cert file must be present")
-            .expose_secret(),
-        &ds_config
-            .tls_configuration
-            .tls_key_content
-            .as_ref()
-            .expect("key file must be present")
-            .expose_secret(),
-    );
-    let tls_config = ServerTlsConfig::new().client_ca_root(ca).identity(identity);
-    server = server.tls_config(tls_config)?;
+    let mut server =
+        tonic::transport::Server::builder().tls_config(get_server_tls_config(config)?)?;
 
     let server_future = server
         .add_routes(get_app_server(&storage).await?)
-        .serve(http_addr);
+        .serve(addr.clone());
 
-    println!("Node {node_id} starting server at {http_addr}");
+    println!("Node {node_id} starting server at {addr}");
     server_future.await?;
 
     Ok(())

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -83,7 +83,7 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
     // Create stores and network
     let (log_store, sm) = crate::new::<crate::TypeConfig, _>(ds_config.path).await?;
     let state_machine_store = Arc::new(sm);
-    let tls_watcher = init_tls_watcher(&config_manager).await?;
+    let tls_watcher = init_tls_watcher(config_manager).await?;
     let network = Arc::new(NetworkManager::new(tls_watcher.clone())?);
 
     // Create Raft instance

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -26,9 +26,10 @@ use openraft::network::{
 };
 use openraft::raft::{StreamAppendError, StreamAppendResult, TransferLeaderRequest};
 use openraft::{AnyError, OptionalSend, RaftNetworkFactory};
+use openstack_keystone_config::RaftTlsConfiguration;
 use secrecy::ExposeSecret;
 use tokio::sync::watch;
-use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, ServerTlsConfig};
 use tracing::error;
 
 use openstack_keystone_config::{Config, ConfigManager};
@@ -302,62 +303,80 @@ impl NetTransferLeader<TypeConfig> for NetworkConnection {
     }
 }
 
-/// Parse the [TlsConfiguration] into the [ClientTlsConfig].
+/// Build the tonic [`ClientTlsConfig`] from the Keystone [`Config`].
 ///
 /// Initialize the [`ClientTlsConfig`] from the distributed_storage or the
 /// listener configuration of the Keystone [`Config`].
 ///
 /// For all of the [`tls_client_ca`, `tls_cert`, `tls_key`] the corresponding
-/// value is searched in the distributed_storage configuration followed by the
-/// listener lookup if not present independently. This way it is possible to
-/// have a dedicated TLS configuration for the Raft cluster while by default the
-/// listener configuration is used.
+/// value is searched in the distributed_storage configuration.
 ///
 /// # Parameters
 /// - `config`: The Keystone [`Config`] instance.
 ///
 /// # Returns
 /// A `Result` containing the `ClientTlsConfig`, or a `StoreError`.
-pub fn load_tls_client_config(config: &Config) -> Result<ClientTlsConfig, StoreError> {
-    let identity = Identity::from_pem(
-        config
-            .distributed_storage
-            .as_ref()
-            .and_then(|x| x.tls_configuration.tls_cert_content.as_ref())
-            .or(config
-                .listener
-                .tls_configuration
-                .as_ref()
-                .and_then(|x| x.tls_cert_content.as_ref()))
-            .ok_or(StoreError::TlsConfigMissing)?
-            .expose_secret(),
-        config
-            .distributed_storage
-            .as_ref()
-            .and_then(|x| x.tls_configuration.tls_key_content.as_ref())
-            .or(config
-                .listener
-                .tls_configuration
-                .as_ref()
-                .and_then(|x| x.tls_key_content.as_ref()))
-            .ok_or(StoreError::TlsConfigMissing)?
-            .expose_secret(),
-    );
-    let mut tls_client_config = ClientTlsConfig::new().identity(identity);
-    if let Some(cert_ca) = config
-        .distributed_storage
-        .as_ref()
-        .and_then(|x| x.tls_configuration.tls_client_ca_content.as_ref())
-        .or(config
-            .listener
-            .tls_configuration
-            .as_ref()
-            .and_then(|x| x.tls_client_ca_content.as_ref()))
+pub fn get_client_tls_config(config: &Config) -> Result<ClientTlsConfig, StoreError> {
+    if let Some(ds) = &config.distributed_storage
+        && let RaftTlsConfiguration::Tls(tls) = &ds.tls_configuration
     {
-        tls_client_config =
-            tls_client_config.ca_certificate(Certificate::from_pem(cert_ca.expose_secret()));
-    };
-    Ok(tls_client_config)
+        let identity = Identity::from_pem(
+            tls.tls_cert_content
+                .as_ref()
+                .ok_or(StoreError::TlsConfigMissing)?
+                .expose_secret(),
+            tls.tls_key_content
+                .as_ref()
+                .ok_or(StoreError::TlsConfigMissing)?
+                .expose_secret(),
+        );
+        let mut tls_client_config = ClientTlsConfig::new().identity(identity);
+        if let Some(cert_ca) = tls.tls_client_ca_content.as_ref() {
+            tls_client_config =
+                tls_client_config.ca_certificate(Certificate::from_pem(cert_ca.expose_secret()));
+        };
+        Ok(tls_client_config)
+    } else {
+        Err(StoreError::TlsConfigMissing)
+    }
+}
+
+/// Build tonic [`ServerTlsConfig`] from the Keystone [`Config`].
+///
+/// Initialize the [`ServerTlsConfig`] from the distributed_storage or the
+/// listener configuration of the Keystone [`Config`].
+///
+/// For all of the [`tls_client_ca`, `tls_cert`, `tls_key`] the corresponding
+/// value is searched in the distributed_storage configuration.
+///
+/// # Parameters
+/// - `config`: The Keystone [`Config`] instance.
+///
+/// # Returns
+/// A `Result` containing the `ServerTlsConfig`, or a `StoreError`.
+pub fn get_server_tls_config(config: &Config) -> Result<ServerTlsConfig, StoreError> {
+    if let Some(ds) = &config.distributed_storage
+        && let RaftTlsConfiguration::Tls(tls) = &ds.tls_configuration
+    {
+        let identity = Identity::from_pem(
+            tls.tls_cert_content
+                .as_ref()
+                .ok_or(StoreError::TlsConfigMissing)?
+                .expose_secret(),
+            tls.tls_key_content
+                .as_ref()
+                .ok_or(StoreError::TlsConfigMissing)?
+                .expose_secret(),
+        );
+        let mut tls_server_config = ServerTlsConfig::new().identity(identity);
+        if let Some(cert_ca) = tls.tls_client_ca_content.as_ref() {
+            tls_server_config =
+                tls_server_config.client_ca_root(Certificate::from_pem(cert_ca.expose_secret()));
+        };
+        Ok(tls_server_config)
+    } else {
+        Err(StoreError::TlsConfigMissing)
+    }
 }
 
 /// Initialize the [ClientTlsConfig] configuration watcher.
@@ -373,7 +392,7 @@ pub async fn init_tls_watcher(
 ) -> Result<watch::Receiver<ClientTlsConfig>, StoreError> {
     // 1. Initial Load: Try to load the certs once to start with a valid state
     let cfg = config_manager.config.read().await;
-    let initial_config = load_tls_client_config(&cfg)?;
+    let initial_config = get_client_tls_config(&cfg)?;
 
     // 2. Create the channel
     let (tx, rx) = watch::channel(initial_config);
@@ -384,7 +403,7 @@ pub async fn init_tls_watcher(
     tokio::spawn(async move {
         while let Ok(_) = reload_rx.recv().await {
             let cfg = cm_clone.config.read().await;
-            match load_tls_client_config(&cfg) {
+            match get_client_tls_config(&cfg) {
                 Ok(new_config) => {
                     // If the cert changed, broadcast to all receivers
                     let _ = tx.send(new_config);

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -27,16 +27,17 @@ use rcgen::{
     BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
     Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
-use secrecy::ExposeSecret;
 use tempfile::TempDir;
-use tonic::transport::{Channel, ClientTlsConfig, Identity, ServerTlsConfig, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Uri};
 
 use openstack_keystone_config::{
     Config, ConfigManager, DistributedStorageConfiguration, TlsConfiguration,
     TlsConfigurationBuilder,
 };
 use openstack_keystone_distributed_storage::app::{Storage, get_app_server, init_storage};
-use openstack_keystone_distributed_storage::network::load_tls_client_config;
+use openstack_keystone_distributed_storage::network::{
+    get_client_tls_config, get_server_tls_config,
+};
 use openstack_keystone_distributed_storage::protobuf as pb;
 use openstack_keystone_distributed_storage::protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient;
 use openstack_keystone_distributed_storage::store_command::*;
@@ -62,10 +63,8 @@ struct InstanceHolder {
 impl InstanceHolder {
     async fn new(node_id: u64, tls_config: TlsConfiguration) -> Result<Self> {
         let storage_dir = tempfile::TempDir::new().unwrap();
-        let addr = get_addr(node_id);
         let ds_config = get_ds_config(node_id, storage_dir.path().to_path_buf(), tls_config);
         let mut config = Config::default();
-        config.listener.cluster_address = Some(addr);
         config.distributed_storage = Some(ds_config);
         let storage = init_storage(&ConfigManager::not_watched(config.clone())).await?;
         Ok(Self {
@@ -82,9 +81,6 @@ async fn test_cluster_inner() -> Result<()> {
     rustls::crypto::CryptoProvider::install_default(provider).unwrap();
 
     let tls_configuration = make_certificates()?;
-    let mut config = Config::default();
-    config.listener.tls_configuration = Some(tls_configuration.clone());
-    let tls_client_config = load_tls_client_config(&config)?;
 
     // --- Start 3 raft node in 3 threads.
     let instance1 = Arc::new(InstanceHolder::new(1, tls_configuration.clone()).await?);
@@ -116,13 +112,15 @@ async fn test_cluster_inner() -> Result<()> {
     // Wait for server to start up.
     TypeConfig::sleep(Duration::from_millis(200)).await;
 
+    let tls_client_config = get_client_tls_config(&instance1.config)?;
+
     let mut admin_client1 = new_admin_client(
         instance1
             .config
             .distributed_storage
             .as_ref()
             .unwrap()
-            .cluster_addr
+            .node_cluster_addr
             .clone(),
         &tls_client_config,
     )
@@ -381,41 +379,18 @@ pub async fn start_raft_app(
     config: &Config,
     storage: &Storage,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let http_addr = config.listener.get_cluster_address();
     let ds_config = config
         .distributed_storage
         .as_ref()
         .expect("ds config must be present");
+    let http_addr = ds_config.node_listener_addr;
     let node_id = ds_config.node_id;
 
-    let mut server = tonic::transport::Server::builder();
-    let ca = tonic::transport::Certificate::from_pem(
-        &ds_config
-            .tls_configuration
-            .tls_client_ca_content
-            .as_ref()
-            .expect("ca cert must be present")
-            .expose_secret(),
-    );
-    let identity = Identity::from_pem(
-        &ds_config
-            .tls_configuration
-            .tls_cert_content
-            .as_ref()
-            .expect("cert file must be present")
-            .expose_secret(),
-        &ds_config
-            .tls_configuration
-            .tls_key_content
-            .as_ref()
-            .expect("key file must be present")
-            .expose_secret(),
-    );
-    let tls_config = ServerTlsConfig::new().client_ca_root(ca).identity(identity);
-    server = server.tls_config(tls_config)?;
+    let tls_config = get_server_tls_config(config)?;
+    let mut server = tonic::transport::Server::builder().tls_config(tls_config)?;
 
     let server_future = server
-        .add_routes(get_app_server(&storage).await?)
+        .add_routes(get_app_server(storage).await?)
         .serve(http_addr);
 
     println!("Node {node_id} starting server at {http_addr}");
@@ -468,9 +443,14 @@ fn get_ds_config(
     tls_config: TlsConfiguration,
 ) -> DistributedStorageConfiguration {
     DistributedStorageConfiguration {
-        cluster_addr: format!("https://{}", get_addr(node_id)).parse().unwrap(),
-        node_id: node_id,
+        node_cluster_addr: format!("https://{}", get_addr(node_id))
+            .parse()
+            .expect("valid address"),
+        node_listener_addr: format!("{}", get_addr(node_id))
+            .parse()
+            .expect("valid address"),
+        node_id,
         path: db_path,
-        tls_configuration: tls_config.clone(),
+        tls_configuration: openstack_keystone_config::RaftTlsConfiguration::Tls(tls_config.clone()),
     }
 }

--- a/crates/webauthn/tests/common/mod.rs
+++ b/crates/webauthn/tests/common/mod.rs
@@ -32,8 +32,8 @@ use uuid::Uuid;
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 
 use openstack_keystone_config::{
-    Config, ConfigManager, DistributedStorageConfiguration, RelyingParty, TlsConfiguration,
-    TlsConfigurationBuilder,
+    Config, ConfigManager, DistributedStorageConfiguration, RaftTlsConfiguration, RelyingParty,
+    TlsConfiguration, TlsConfigurationBuilder,
 };
 use openstack_keystone_core::SqlDriverRegistration;
 use openstack_keystone_core::keystone::Service;
@@ -145,10 +145,11 @@ pub async fn get_state(
     if std::env::var("DATABASE_URL").is_err() {
         let tls_configuration = make_certificates()?;
         cfg.distributed_storage = Some(DistributedStorageConfiguration {
-            cluster_addr: "http://127.0.0.1:12345".parse()?,
+            node_cluster_addr: "http://127.0.0.1:12345".parse()?,
+            node_listener_addr: "127.0.0.1:1234".parse()?,
             node_id: 1,
             path: tmp_db_dir.path().to_path_buf(),
-            tls_configuration,
+            tls_configuration: RaftTlsConfiguration::Tls(tls_configuration),
         });
     }
     let mut policy_enforcer_mock = MockPolicy::default();

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -45,7 +45,6 @@ profiles:
         useDockerCLI: true
         concurrency: 0
         push: true
-        #tryImportMissing: true
 manifests:
   kustomize:
     paths:
@@ -85,6 +84,16 @@ deploy:
         namespace: cert-manager
         setValues:
           crds.enabled: true
+      - name: spire-crds
+        repo: https://spiffe.github.io/helm-charts-hardened
+        remoteChart: spire-crds
+        namespace: spire
+        createNamespace: true
+      - name: spire
+        repo: https://spiffe.github.io/helm-charts-hardened
+        remoteChart: spire
+        namespace: spire
+
 verify:
   - name: "api-test"
     container:

--- a/tests/integration/src/common.rs
+++ b/tests/integration/src/common.rs
@@ -149,9 +149,11 @@ pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
     if std::env::var("USE_RAFT").is_ok() {
         let tmp_db_dir = tmp_dir.path().join("certs");
         create_dir(&tmp_db_dir)?;
-        let tls_configuration = make_certificates()?;
+        let tls_configuration =
+            openstack_keystone_config::RaftTlsConfiguration::Tls(make_certificates()?);
         cfg.distributed_storage = Some(DistributedStorageConfiguration {
-            cluster_addr: "http://127.0.0.1:12345".parse()?,
+            node_cluster_addr: "http://127.0.0.1:12345".parse()?,
+            node_listener_addr: "127.0.0.1:12345".parse()?,
             node_id: 1,
             path: tmp_db_dir.to_path_buf(),
             tls_configuration,

--- a/tools/k8s/keystone/base/conf/keystone.conf
+++ b/tools/k8s/keystone/base/conf/keystone.conf
@@ -15,5 +15,10 @@ relying_party_id = local
 relying_party_origin = https://keystone.local
 relying_party_name = keystone
 
-[listener]
-cluster_address = 0.0.0.0:8300
+#[interface_public]
+#cluster_address = 0.0.0.0:8300
+
+[interface_internal]
+tcp_address = 0.0.0.0:8215
+type = "spiffe"
+trust_domains = "example.org"

--- a/tools/k8s/keystone/base/deployment-py.yaml
+++ b/tools/k8s/keystone/base/deployment-py.yaml
@@ -16,11 +16,24 @@ spec:
       labels:
         app.kubernetes.io/name: keystone-py
     spec:
+      #serviceAccountName: keystone
       initContainers:
         - name: db-waiter
           image: busybox:1.36.1
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'echo "Waiting for PostgreSQL to be available..."; while ! nc -z -w 1 keystone-db-rw 5432; do echo "Still waiting for postgres-service..."; sleep 2; done; echo "PostgreSQL is available! Starting application."']
+
+        - name: client
+          image: ghcr.io/spiffe/spire-agent:1.14.5
+          command: ["/opt/spire/bin/spire-agent"]
+          args: [ "api", "fetch",  "x509", "-write", "/tmp/spiffe", "-socketPath", "/run/spire/sockets/spire-agent.sock" ]
+          volumeMounts:
+            - name: spiffe-workload-api
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: certs
+              mountPath: /tmp/spiffe
+
       containers:
         - env:
             - name: OS_DATABASE__CONNECTION
@@ -68,6 +81,8 @@ spec:
             - mountPath: /etc/keystone/keystone.conf
               name: config
               subPath: keystone.conf
+            - mountPath: /tmp/spiffe
+              name: certs
 
       volumes:
         - name: config
@@ -83,3 +98,14 @@ spec:
                 path: "0"
               - key: "k1"
                 path: "1"
+        - name: "spire-agent-socket"
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+
+        - name: "spiffe-workload-api"
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true
+        - name: certs
+          emptyDir: {}

--- a/tools/k8s/keystone/base/kustomization.yaml
+++ b/tools/k8s/keystone/base/kustomization.yaml
@@ -22,5 +22,6 @@ resources:
   - deployment-py.yaml
   - statefulset-rs.yaml
   - db.yaml
+  - sa.yaml
   - service.yaml
   - ingress.yaml

--- a/tools/k8s/keystone/base/sa.yaml
+++ b/tools/k8s/keystone/base/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keystone

--- a/tools/k8s/keystone/base/service.yaml
+++ b/tools/k8s/keystone/base/service.yaml
@@ -25,6 +25,10 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: 8080
+    - name: https-rs
+      port: 8215
+      protocol: TCP
+      targetPort: 8215
   selector:
     app.kubernetes.io/name: keystone-rs
 

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app.kubernetes.io/name: keystone-rs
     spec:
+      serviceAccountName: keystone
       initContainers:
         - name: db-waiter
           image: busybox
@@ -45,7 +46,8 @@ spec:
               cat <<EOF > /etc/keystone/site.toml
               [distributed_storage]
               node_id = $NODE_ID
-              cluster_addr = "https://$POD_NAME.keystone-rs-internal.default.svc.cluster.local:8300"
+              node_cluster_addr = "https://$POD_NAME.keystone-rs-internal.default.svc.cluster.local:8300"
+              node_listener_addr = "0.0.0.0:8300"
               path = "/storage"
               tls_client_ca_file = "/certs/ca.crt"
               tls_cert_file = "/certs/tls.crt"
@@ -53,13 +55,15 @@ spec:
               EOF
       containers:
         - env:
-            - name: OS_DATABASE__CONNECTION
+            - name: "OS_DATABASE__CONNECTION"
               valueFrom:
                 secretKeyRef:
-                  key: fqdn-uri
-                  name: keystone-db-app
-            - name: KEYSTONE_SITE_VARS_FILE
+                  key: "fqdn-uri"
+                  name: "keystone-db-app"
+            - name: "KEYSTONE_SITE_VARS_FILE"
               value: "/etc/keystone/site.toml"
+            - name: "SPIFFE_ENDPOINT_SOCKET"
+              value: "unix:///run/spire/sockets/spire-agent.sock"
           command: ["keystone", "-vv"]
 
           image: keystone-rs
@@ -67,6 +71,9 @@ spec:
           ports:
             - containerPort: 8080
               name: keystone-rs
+              protocol: TCP
+            - containerPort: 8215
+              name: spiffe
               protocol: TCP
             - containerPort: 8300
               name: keystone-raft
@@ -111,6 +118,9 @@ spec:
               name: config
               subPath: keystone.conf
               readOnly: true
+            - mountPath: /run/spire/sockets
+              name: spiffe-workload-api
+              readOnly: true
 
         - command: ["opa", "run", "--server", "/policy", "--addr", ":8181", "--log-level", "debug"]
           image: opa
@@ -145,3 +155,7 @@ spec:
           emptyDir: {}
         - name: raft-config-shared
           emptyDir: {}
+        - name: "spiffe-workload-api"
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true


### PR DESCRIPTION
- add concept of interfaces with various listener types
- add spiffe based tls listener for the rest api passing SVID through
  request extensions up to the extractors for evaluation
- pass interface as extension to the request to be able to analyze it in
  policy
- prepare raft app for the spiffe support
